### PR TITLE
GD-1286: Cache test discovery results to avoid re-loading unchanged suites on every run

### DIFF
--- a/addons/gdUnit4/src/core/GdUnitSettings.gd
+++ b/addons/gdUnit4/src/core/GdUnitSettings.gd
@@ -19,6 +19,7 @@ const TEST_TIMEOUT = GROUP_TEST + "/test_timeout_seconds"
 const TEST_LOOKUP_FOLDER = GROUP_TEST + "/test_lookup_folder"
 const TEST_SUITE_NAMING_CONVENTION = GROUP_TEST + "/test_suite_naming_convention"
 const TEST_DISCOVER_ENABLED = GROUP_TEST + "/test_discovery"
+const TEST_DISCOVERY_CACHE = GROUP_TEST + "/discovery_cache"
 const TEST_FLAKY_CHECK = GROUP_TEST + "/flaky_check_enable"
 const TEST_FLAKY_MAX_RETRIES = GROUP_TEST + "/flaky_max_retries"
 const TEST_RERUN_UNTIL_FAILURE_RETRIES = GROUP_TEST + "/rerun_until_failure_retries"
@@ -128,6 +129,7 @@ static func setup() -> void:
 	create_property_if_need(TEST_LOOKUP_FOLDER, DEFAULT_TEST_LOOKUP_FOLDER, HELP_TEST_LOOKUP_FOLDER)
 	create_property_if_need(TEST_SUITE_NAMING_CONVENTION, NAMING_CONVENTIONS.AUTO_DETECT, "Naming convention to use when generating testsuites", NAMING_CONVENTIONS.keys())
 	create_property_if_need(TEST_DISCOVER_ENABLED, false, "Automatically detect new tests in test lookup folders at runtime")
+	create_property_if_need(TEST_DISCOVERY_CACHE, true, "Cache discovered tests by file modification time to speed up repeated test runs")
 	create_property_if_need(TEST_FLAKY_CHECK, false, "Rerun tests on failure and mark them as FLAKY")
 	create_property_if_need(TEST_FLAKY_MAX_RETRIES, 3, "Sets the number of retries for rerunning a flaky test")
 	create_property_if_need(TEST_RERUN_UNTIL_FAILURE_RETRIES, 10, "The number of reruns until the test fails.")
@@ -314,6 +316,10 @@ static func is_inspector_toolbar_button_show() -> bool:
 
 static func is_test_discover_enabled() -> bool:
 	return get_setting(TEST_DISCOVER_ENABLED, false)
+
+
+static func is_discovery_cache_enabled() -> bool:
+	return get_setting(TEST_DISCOVERY_CACHE, true)
 
 
 static func is_test_flaky_check_enabled() -> bool:

--- a/addons/gdUnit4/src/core/GdUnitTestSuiteScanner.gd
+++ b/addons/gdUnit4/src/core/GdUnitTestSuiteScanner.gd
@@ -54,6 +54,12 @@ func scan(resource_path: String) -> Array[Script]:
 	return scan_directory(resource_path)
 
 
+## Loads the script at [param resource_path] and returns it when it is a test suite,[br]
+## otherwise null. Expects [method prescan_testsuite_classes] to have been called once.
+func discover_suite_script(resource_path: String) -> Script:
+	return _load_is_test_suite(resource_path)
+
+
 func scan_directory(resource_path: String) -> Array[Script]:
 	prescan_testsuite_classes()
 	# We use the global cache to fast scan for test suites.

--- a/addons/gdUnit4/src/core/discovery/GdUnitDiscoverCache.gd
+++ b/addons/gdUnit4/src/core/discovery/GdUnitDiscoverCache.gd
@@ -1,0 +1,96 @@
+## A persistent, file-modification-time keyed cache of discovered test cases.[br]
+## [br]
+## Test discovery loads (compiles) every candidate script to determine whether it is a[br]
+## test suite and to extract its test methods. For a large project this dominates the[br]
+## discovery cost. This cache stores the discovered [GdUnitTestCase]s per source file,[br]
+## keyed by the file's modification time, so unchanged files are served from the cache[br]
+## without ever loading the script.[br]
+## [br]
+## A file that is not a test suite is cached as an empty entry so it is not re-loaded on[br]
+## subsequent runs either. The cache is stored under [code]res://.godot/[/code] which is[br]
+## per-project and excluded from version control.
+class_name GdUnitDiscoverCache
+extends RefCounted
+
+const DEFAULT_CACHE_FILE := "res://.godot/gdunit_discover_cache.json"
+
+## Bump when the serialized shape or discovery semantics change to invalidate stale caches.
+const CACHE_VERSION := 1
+
+var _cache_file: String
+# source_file -> { "mtime": int, "tests": Array[Dictionary] }
+var _entries: Dictionary = {}
+var _dirty := false
+
+
+func _init(cache_file := DEFAULT_CACHE_FILE) -> void:
+	_cache_file = cache_file
+
+
+## Loads the cache from disk. Starts empty when no cache exists or the format version differs.
+func load_cache() -> void:
+	if not FileAccess.file_exists(_cache_file):
+		return
+	var file := FileAccess.open(_cache_file, FileAccess.READ)
+	if file == null:
+		return
+	var data: Variant = JSON.parse_string(file.get_as_text())
+	if not data is Dictionary:
+		return
+	# Discard a cache written by a different format version.
+	if int((data as Dictionary).get("version", -1)) != CACHE_VERSION:
+		return
+	var entries: Variant = (data as Dictionary).get("entries", {})
+	if entries is Dictionary:
+		_entries = entries
+
+
+## Writes the cache back to disk when it has changed.
+func save_cache() -> void:
+	if not _dirty:
+		return
+	var file := FileAccess.open(_cache_file, FileAccess.WRITE)
+	if file == null:
+		push_warning("GdUnitDiscoverCache: unable to write cache at %s" % _cache_file)
+		return
+	file.store_string(JSON.stringify({ "version": CACHE_VERSION, "entries": _entries }))
+	_dirty = false
+
+
+## Returns true when a valid, up-to-date entry exists for [param source_file].
+func is_valid(source_file: String, mtime: int) -> bool:
+	var entry: Variant = _entries.get(source_file)
+	return entry is Dictionary and int((entry as Dictionary).get("mtime", -1)) == mtime
+
+
+## Returns the cached test cases for [param source_file]. Only call after [method is_valid].
+func get_tests(source_file: String) -> Array[GdUnitTestCase]:
+	var tests: Array[GdUnitTestCase] = []
+	var entry: Variant = _entries.get(source_file)
+	if not entry is Dictionary:
+		return tests
+	for dict: Variant in (entry as Dictionary).get("tests", []):
+		if dict is Dictionary:
+			tests.append(GdUnitTestCase.from_dict(dict))
+	return tests
+
+
+## Stores the discovered [param tests] for [param source_file] under its [param mtime].
+func put(source_file: String, mtime: int, tests: Array[GdUnitTestCase]) -> void:
+	var serialized: Array = []
+	for test in tests:
+		serialized.append(GdUnitTestCase.to_dict(test))
+	_entries[source_file] = { "mtime": mtime, "tests": serialized }
+	_dirty = true
+
+
+## Removes cached entries whose source file is not contained in [param present_files].
+func prune(present_files: PackedStringArray) -> void:
+	var present := {}
+	for source_file in present_files:
+		present[source_file] = true
+	for key: String in _entries.keys():
+		if not present.has(key):
+			@warning_ignore("return_value_discarded")
+			_entries.erase(key)
+			_dirty = true

--- a/addons/gdUnit4/src/core/discovery/GdUnitDiscoverCache.gd
+++ b/addons/gdUnit4/src/core/discovery/GdUnitDiscoverCache.gd
@@ -27,14 +27,22 @@ func _init(cache_file := DEFAULT_CACHE_FILE) -> void:
 	_cache_file = cache_file
 
 
-## Loads the cache from disk. Starts empty when no cache exists or the format version differs.
+## Loads the cache from disk. Starts empty when no cache exists, the file is unreadable,[br]
+## the content is not valid JSON (e.g. a partially written file), or the format version differs.
 func load_cache() -> void:
 	if not FileAccess.file_exists(_cache_file):
 		return
 	var file := FileAccess.open(_cache_file, FileAccess.READ)
 	if file == null:
 		return
-	var data: Variant = JSON.parse_string(file.get_as_text())
+	var text := file.get_as_text()
+	file.close()
+	# Parse via an instance so a malformed cache is ignored silently instead of pushing an
+	# engine error to the console; the cache is simply rebuilt on this run.
+	var json := JSON.new()
+	if json.parse(text) != OK:
+		return
+	var data: Variant = json.data
 	if not data is Dictionary:
 		return
 	# Discard a cache written by a different format version.
@@ -45,15 +53,31 @@ func load_cache() -> void:
 		_entries = entries
 
 
-## Writes the cache back to disk when it has changed.
+## Writes the cache back to disk when it has changed. The write goes to a per-instance[br]
+## temporary file that is then renamed into place, so overlapping discovery runs can never[br]
+## read a half-written cache.
 func save_cache() -> void:
 	if not _dirty:
 		return
-	var file := FileAccess.open(_cache_file, FileAccess.WRITE)
+	# Unique across processes (pid) and within a process (instance id) so overlapping
+	# writers never share a temporary file.
+	var tmp_file := "%s.%d.%d.tmp" % [_cache_file, OS.get_process_id(), get_instance_id()]
+	var file := FileAccess.open(tmp_file, FileAccess.WRITE)
 	if file == null:
 		push_warning("GdUnitDiscoverCache: unable to write cache at %s" % _cache_file)
 		return
 	file.store_string(JSON.stringify({ "version": CACHE_VERSION, "entries": _entries }))
+	file.close()
+	# Atomically replace the cache. On platforms where rename does not overwrite, remove first.
+	if DirAccess.rename_absolute(tmp_file, _cache_file) != OK:
+		if FileAccess.file_exists(_cache_file):
+			@warning_ignore("return_value_discarded")
+			DirAccess.remove_absolute(_cache_file)
+		if DirAccess.rename_absolute(tmp_file, _cache_file) != OK:
+			@warning_ignore("return_value_discarded")
+			DirAccess.remove_absolute(tmp_file)
+			push_warning("GdUnitDiscoverCache: unable to persist cache at %s" % _cache_file)
+			return
 	_dirty = false
 
 

--- a/addons/gdUnit4/src/core/discovery/GdUnitDiscoverCache.gd
+++ b/addons/gdUnit4/src/core/discovery/GdUnitDiscoverCache.gd
@@ -59,23 +59,29 @@ func load_cache() -> void:
 func save_cache() -> void:
 	if not _dirty:
 		return
+	# The DirAccess *_absolute APIs operate on filesystem paths, so resolve res://.
+	var abs_cache := ProjectSettings.globalize_path(_cache_file)
+	var abs_dir := abs_cache.get_base_dir()
+	if not DirAccess.dir_exists_absolute(abs_dir):
+		@warning_ignore("return_value_discarded")
+		DirAccess.make_dir_recursive_absolute(abs_dir)
 	# Unique across processes (pid) and within a process (instance id) so overlapping
 	# writers never share a temporary file.
-	var tmp_file := "%s.%d.%d.tmp" % [_cache_file, OS.get_process_id(), get_instance_id()]
-	var file := FileAccess.open(tmp_file, FileAccess.WRITE)
+	var abs_tmp := "%s.%d.%d.tmp" % [abs_cache, OS.get_process_id(), get_instance_id()]
+	var file := FileAccess.open(abs_tmp, FileAccess.WRITE)
 	if file == null:
 		push_warning("GdUnitDiscoverCache: unable to write cache at %s" % _cache_file)
 		return
 	file.store_string(JSON.stringify({ "version": CACHE_VERSION, "entries": _entries }))
 	file.close()
 	# Atomically replace the cache. On platforms where rename does not overwrite, remove first.
-	if DirAccess.rename_absolute(tmp_file, _cache_file) != OK:
-		if FileAccess.file_exists(_cache_file):
+	if DirAccess.rename_absolute(abs_tmp, abs_cache) != OK:
+		if FileAccess.file_exists(abs_cache):
 			@warning_ignore("return_value_discarded")
-			DirAccess.remove_absolute(_cache_file)
-		if DirAccess.rename_absolute(tmp_file, _cache_file) != OK:
+			DirAccess.remove_absolute(abs_cache)
+		if DirAccess.rename_absolute(abs_tmp, abs_cache) != OK:
 			@warning_ignore("return_value_discarded")
-			DirAccess.remove_absolute(tmp_file)
+			DirAccess.remove_absolute(abs_tmp)
 			push_warning("GdUnitDiscoverCache: unable to persist cache at %s" % _cache_file)
 			return
 	_dirty = false

--- a/addons/gdUnit4/src/core/discovery/GdUnitTestDiscoverer.gd
+++ b/addons/gdUnit4/src/core/discovery/GdUnitTestDiscoverer.gd
@@ -20,6 +20,10 @@ static func run() -> Array[GdUnitTestCase]:
 
 		var collected_tests: Array[GdUnitTestCase] = []
 		if GdUnitSettings.is_discovery_cache_enabled():
+			# Sync to the main thread first: a warm cache serves tests in a few ms without
+			# loading scripts, so discovery runs on the main thread and safely creates the
+			# suite instances and emits to the inspector there.
+			await (Engine.get_main_loop() as SceneTree).process_frame
 			collected_tests = discover_tests_cached(test_suite_directories, func(test_case: GdUnitTestCase) -> void:
 				GdUnitTestDiscoverSink.discover(test_case)
 			, recovered_tests)

--- a/addons/gdUnit4/src/core/discovery/GdUnitTestDiscoverer.gd
+++ b/addons/gdUnit4/src/core/discovery/GdUnitTestDiscoverer.gd
@@ -19,20 +19,25 @@ static func run() -> Array[GdUnitTestCase]:
 		var scanner := GdUnitTestSuiteScanner.new()
 
 		var collected_tests: Array[GdUnitTestCase] = []
-		var collected_test_suites: Array[Script] = []
-		# collect test suites
-		for test_suite_dir in test_suite_directories:
-			collected_test_suites.append_array(scanner.scan_directory(test_suite_dir))
-
-		# Do sync the main thread before emit the discovered test suites to the inspector
-		await (Engine.get_main_loop() as SceneTree).process_frame
-		for test_suites_script in collected_test_suites:
-			discover_tests(test_suites_script, func(test_case: GdUnitTestCase) -> void:
-				# Sync test uid from last test session
-				recover_test_guid(test_case, recovered_tests)
-				collected_tests.append(test_case)
+		if GdUnitSettings.is_discovery_cache_enabled():
+			collected_tests = discover_tests_cached(test_suite_directories, func(test_case: GdUnitTestCase) -> void:
 				GdUnitTestDiscoverSink.discover(test_case)
-			)
+			, recovered_tests)
+		else:
+			var collected_test_suites: Array[Script] = []
+			# collect test suites
+			for test_suite_dir in test_suite_directories:
+				collected_test_suites.append_array(scanner.scan_directory(test_suite_dir))
+
+			# Do sync the main thread before emit the discovered test suites to the inspector
+			await (Engine.get_main_loop() as SceneTree).process_frame
+			for test_suites_script in collected_test_suites:
+				discover_tests(test_suites_script, func(test_case: GdUnitTestCase) -> void:
+					# Sync test uid from last test session
+					recover_test_guid(test_case, recovered_tests)
+					collected_tests.append(test_case)
+					GdUnitTestDiscoverSink.discover(test_case)
+				)
 
 		console_log_discover_results(collected_tests)
 		if !recovered_tests.is_empty():
@@ -118,6 +123,89 @@ static func discover_tests(source_script: Script, discover_sink := default_disco
 			return
 		for test_case in GdUnit4CSharpApiLoader.discover_tests(source_script):
 			discover_sink.call(test_case)
+
+
+## Discovers tests across [param root_paths], serving unchanged files from a persistent[br]
+## modification-time cache so their scripts are never loaded. Each discovered test is passed[br]
+## to [param discover_sink] and, when [param recovered_tests] is provided, its GUID is synced[br]
+## from the previous session. Returns all discovered tests.
+static func discover_tests_cached(
+	root_paths: PackedStringArray,
+	discover_sink := default_discover_sink,
+	recovered_tests: Array[GdUnitTestCase] = []) -> Array[GdUnitTestCase]:
+
+	var cache := GdUnitDiscoverCache.new()
+	cache.load_cache()
+	var scanner := GdUnitTestSuiteScanner.new()
+	scanner.prescan_testsuite_classes()
+
+	var collected: Array[GdUnitTestCase] = []
+	var visited := PackedStringArray()
+	for root in root_paths:
+		var files := PackedStringArray()
+		if FileAccess.file_exists(root):
+			@warning_ignore("return_value_discarded")
+			files.append(root)
+		else:
+			collect_test_files(root, files)
+		for source_file in files:
+			@warning_ignore("return_value_discarded")
+			visited.append(source_file)
+			var mtime := int(FileAccess.get_modified_time(source_file))
+			var tests: Array[GdUnitTestCase]
+			if cache.is_valid(source_file, mtime):
+				tests = cache.get_tests(source_file)
+			else:
+				tests = discover_file(scanner, source_file)
+				cache.put(source_file, mtime, tests)
+			for test_case in tests:
+				if not recovered_tests.is_empty():
+					recover_test_guid(test_case, recovered_tests)
+				collected.append(test_case)
+				discover_sink.call(test_case)
+	cache.prune(visited)
+	cache.save_cache()
+	return collected
+
+
+## Loads [param source_file] and returns its test cases, or an empty array when it is not a suite.
+static func discover_file(scanner: GdUnitTestSuiteScanner, source_file: String) -> Array[GdUnitTestCase]:
+	var script := scanner.discover_suite_script(source_file)
+	if script == null:
+		return []
+	var tests: Array[GdUnitTestCase] = []
+	discover_tests(script, func(test_case: GdUnitTestCase) -> void:
+		tests.append(test_case)
+	)
+	return tests
+
+
+## Recursively collects supported script paths under [param root_path] without loading them,[br]
+## honoring [code].gdignore[/code] files and the scanner's excluded directories.
+static func collect_test_files(root_path: String, collected: PackedStringArray) -> PackedStringArray:
+	if GdUnitTestSuiteScanner.exclude_scan_directories.has(root_path):
+		return collected
+	var dir := DirAccess.open(root_path)
+	if dir == null:
+		return collected
+	if dir.file_exists(".gdignore"):
+		return collected
+	if dir.list_dir_begin() != OK:
+		return collected
+	var file_name := dir.get_next()
+	while file_name != "":
+		var current := dir.get_current_dir()
+		var path := current + file_name if current.ends_with("/") else current + "/" + file_name
+		if dir.current_is_dir():
+			@warning_ignore("return_value_discarded")
+			collect_test_files(path, collected)
+		else:
+			var ext := path.get_extension()
+			if ext == "gd" or (ext == "cs" and ClassDB.class_exists("CSharpScript")):
+				@warning_ignore("return_value_discarded")
+				collected.append(path)
+		file_name = dir.get_next()
+	return collected
 
 
 static func discover_tests_from_gd_script(script: GDScript) -> Array[GdUnitTestCase]:

--- a/addons/gdUnit4/src/core/runners/GdUnitTestCIRunner.gd
+++ b/addons/gdUnit4/src/core/runners/GdUnitTestCIRunner.gd
@@ -402,13 +402,21 @@ func discover_tests() -> Array[GdUnitTestCase]:
 	var gdunit_test_discover_added := GdUnitSignals.instance().gdunit_test_discover_added
 
 	_test_cases = _runner_config.test_cases()
+	if GdUnitSettings.is_discovery_cache_enabled():
+		GdUnitTestDiscoverer.discover_tests_cached(_included_tests, func(test: GdUnitTestCase) -> void:
+			if not is_skipped(test):
+				_test_cases.append(test)
+				gdunit_test_discover_added.emit(test)
+		)
+		return _test_cases
+
 	var scanner := GdUnitTestSuiteScanner.new()
 	for path in _included_tests:
 		var scripts := scanner.scan(path)
 		for script in scripts:
 			GdUnitTestDiscoverer.discover_tests(script, func(test: GdUnitTestCase) -> void:
+				#_console.println_message("discoverd %s" % test.display_name)
 				if not is_skipped(test):
-					#_console.println_message("discoverd %s" % test.display_name)
 					_test_cases.append(test)
 					gdunit_test_discover_added.emit(test)
 			)

--- a/addons/gdUnit4/src/core/runners/GdUnitTestCIRunner.gd
+++ b/addons/gdUnit4/src/core/runners/GdUnitTestCIRunner.gd
@@ -415,7 +415,6 @@ func discover_tests() -> Array[GdUnitTestCase]:
 		var scripts := scanner.scan(path)
 		for script in scripts:
 			GdUnitTestDiscoverer.discover_tests(script, func(test: GdUnitTestCase) -> void:
-				#_console.println_message("discoverd %s" % test.display_name)
 				if not is_skipped(test):
 					_test_cases.append(test)
 					gdunit_test_discover_added.emit(test)

--- a/addons/gdUnit4/test/core/discovery/GdUnitDiscoverCacheTest.gd
+++ b/addons/gdUnit4/test/core/discovery/GdUnitDiscoverCacheTest.gd
@@ -78,6 +78,17 @@ func test_version_guard_discards_foreign_cache() -> void:
 	assert_bool(cache.is_valid("res://test/FooTest.gd", 100)).is_false()
 
 
+func test_corrupt_cache_is_ignored() -> void:
+	# A partially written / malformed cache must be ignored, not crash or spam errors.
+	var file := FileAccess.open(_cache_file, FileAccess.WRITE)
+	file.store_string('{"version": 1, "entries": {"res://a.gd": {"mtime": 1')
+	file.close()
+
+	var cache := GdUnitDiscoverCache.new(_cache_file)
+	cache.load_cache()
+	assert_bool(cache.is_valid("res://a.gd", 1)).is_false()
+
+
 func test_prune_removes_absent_files() -> void:
 	var cache := GdUnitDiscoverCache.new(_cache_file)
 	cache.put("res://test/FooTest.gd", 100, [_test_case("res://test/FooTest.gd")])

--- a/addons/gdUnit4/test/core/discovery/GdUnitDiscoverCacheTest.gd
+++ b/addons/gdUnit4/test/core/discovery/GdUnitDiscoverCacheTest.gd
@@ -1,0 +1,89 @@
+# GdUnit generated TestSuite
+class_name GdUnitDiscoverCacheTest
+extends GdUnitTestSuite
+
+
+const __source = "res://addons/gdUnit4/src/core/discovery/GdUnitDiscoverCache.gd"
+
+
+var _cache_file: String
+
+
+func before_test() -> void:
+	_cache_file = "user://gdunit_discover_cache_test_%d.json" % Time.get_ticks_usec()
+
+
+func after_test() -> void:
+	if FileAccess.file_exists(_cache_file):
+		DirAccess.remove_absolute(ProjectSettings.globalize_path(_cache_file))
+
+
+func _test_case(source_file := "res://test/FooTest.gd", test_name := "test_bar") -> GdUnitTestCase:
+	return GdUnitTestCase.from(source_file, source_file, 10, test_name)
+
+
+#region cache lookup
+func test_is_valid_false_when_absent() -> void:
+	var cache := GdUnitDiscoverCache.new(_cache_file)
+	assert_bool(cache.is_valid("res://test/FooTest.gd", 100)).is_false()
+
+
+func test_is_valid_false_on_mtime_change() -> void:
+	var cache := GdUnitDiscoverCache.new(_cache_file)
+	cache.put("res://test/FooTest.gd", 100, [_test_case()])
+	assert_bool(cache.is_valid("res://test/FooTest.gd", 100)).is_true()
+	assert_bool(cache.is_valid("res://test/FooTest.gd", 101)).is_false()
+#endregion
+
+
+#region persistence
+func test_put_and_get_round_trip() -> void:
+	var cache := GdUnitDiscoverCache.new(_cache_file)
+	cache.put("res://test/FooTest.gd", 100, [_test_case("res://test/FooTest.gd", "test_bar")])
+	cache.save_cache()
+
+	var reloaded := GdUnitDiscoverCache.new(_cache_file)
+	reloaded.load_cache()
+	assert_bool(reloaded.is_valid("res://test/FooTest.gd", 100)).is_true()
+	var tests := reloaded.get_tests("res://test/FooTest.gd")
+	assert_int(tests.size()).is_equal(1)
+	assert_str(tests[0].test_name).is_equal("test_bar")
+	assert_str(tests[0].source_file).is_equal("res://test/FooTest.gd")
+
+
+func test_empty_entry_is_cached_and_valid() -> void:
+	# A file that is not a test suite must be cached as empty so it is not re-loaded.
+	var cache := GdUnitDiscoverCache.new(_cache_file)
+	cache.put("res://test/helper.gd", 100, [])
+	cache.save_cache()
+
+	var reloaded := GdUnitDiscoverCache.new(_cache_file)
+	reloaded.load_cache()
+	assert_bool(reloaded.is_valid("res://test/helper.gd", 100)).is_true()
+	assert_int(reloaded.get_tests("res://test/helper.gd").size()).is_equal(0)
+#endregion
+
+
+#region invalidation
+func test_version_guard_discards_foreign_cache() -> void:
+	var file := FileAccess.open(_cache_file, FileAccess.WRITE)
+	file.store_string(JSON.stringify({
+		"version": GdUnitDiscoverCache.CACHE_VERSION + 1,
+		"entries": { "res://test/FooTest.gd": { "mtime": 100, "tests": [] } }
+	}))
+	file.close()
+
+	var cache := GdUnitDiscoverCache.new(_cache_file)
+	cache.load_cache()
+	assert_bool(cache.is_valid("res://test/FooTest.gd", 100)).is_false()
+
+
+func test_prune_removes_absent_files() -> void:
+	var cache := GdUnitDiscoverCache.new(_cache_file)
+	cache.put("res://test/FooTest.gd", 100, [_test_case("res://test/FooTest.gd")])
+	cache.put("res://test/BarTest.gd", 200, [_test_case("res://test/BarTest.gd")])
+
+	cache.prune(["res://test/FooTest.gd"])
+	assert_bool(cache.is_valid("res://test/FooTest.gd", 100)).is_true()
+	assert_bool(cache.is_valid("res://test/BarTest.gd", 200)).is_false()
+#endregion

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -1,0 +1,36 @@
+# Discovery-cache benchmark
+
+`bench_runner.sh` measures the effect of the persistent test-discovery cache
+(`settings/test/discovery_cache`) on a target Godot project.
+
+It syncs this repo's `addons/gdUnit4` into the target project, warms the import cache,
+then times a **cold** run (discovery cache cleared) against **warm** runs (cache present).
+The difference is the discovery cost the cache removes; test execution time is unaffected.
+
+## Usage
+
+```bash
+benchmark/bench_runner.sh \
+  --godot "/path/to/godot" \
+  --project ../my-project \
+  --iterations 5
+```
+
+Options:
+
+- `--godot` — path to the Godot binary (required)
+- `--project` — path to the target project containing a `project.godot` (required)
+- `--iterations` — number of warm runs to median over (default 5)
+- `--filter` — test path to run (default `res://test/`)
+- `--no-sync` — do not copy the addon into the target first
+
+## Example result
+
+Measured on a project of 629 tests across 89 suites (Godot 4.7.1, macOS):
+
+| Run | Discovery |
+| --- | ---: |
+| Cold (builds cache) | ~1580 ms |
+| Warm | ~14 ms |
+
+About 1.57 s saved per warm run, scaling with the number of suites.

--- a/benchmark/bench_runner.sh
+++ b/benchmark/bench_runner.sh
@@ -1,0 +1,95 @@
+#!/bin/bash
+# GdUnit4 test-discovery benchmark.
+#
+# Measures the effect of the persistent discovery cache on a target Godot project by
+# comparing a cold run (cache cleared) against warm runs (cache present). The difference
+# is the discovery cost the cache removes; execution time is unaffected.
+#
+# It syncs this repo's addons/gdUnit4 into the target project before running, so the
+# numbers reflect the addon revision currently checked out here.
+#
+# Usage:
+#   benchmark/bench_runner.sh --godot <godot-bin> --project <path> [--iterations N] [--filter res://test/] [--no-sync]
+#
+# Example:
+#   benchmark/bench_runner.sh \
+#     --godot "/Applications/Godot 4.7.1.app/Contents/MacOS/Godot" \
+#     --project ../my-project --iterations 5
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+GODOT=""
+PROJECT=""
+ITERATIONS=5
+FILTER="res://test/"
+DO_SYNC=1
+
+while [ $# -gt 0 ]; do
+	case "$1" in
+		--godot) GODOT="$2"; shift 2 ;;
+		--project) PROJECT="$2"; shift 2 ;;
+		--iterations) ITERATIONS="$2"; shift 2 ;;
+		--filter) FILTER="$2"; shift 2 ;;
+		--no-sync) DO_SYNC=0; shift ;;
+		*) echo "Unknown argument: $1" >&2; exit 2 ;;
+	esac
+done
+
+[ -n "$GODOT" ] || { echo "--godot is required" >&2; exit 2; }
+[ -n "$PROJECT" ] || { echo "--project is required" >&2; exit 2; }
+[ -x "$GODOT" ] || { echo "Godot binary not executable: $GODOT" >&2; exit 2; }
+PROJECT="$(cd "$PROJECT" && pwd)"
+[ -f "$PROJECT/project.godot" ] || { echo "No project.godot in $PROJECT" >&2; exit 2; }
+
+if [ "$DO_SYNC" = "1" ]; then
+	echo "Syncing addons/gdUnit4 -> $PROJECT ..."
+	rsync -a --delete "$REPO_ROOT/addons/gdUnit4/" "$PROJECT/addons/gdUnit4/"
+fi
+
+CACHE_FILE="$PROJECT/.godot/gdunit_discover_cache.json"
+
+# Warm the import cache once so import time is excluded from the timed runs.
+echo "Warming import cache ..."
+"$GODOT" --headless --import --path "$PROJECT" >/dev/null 2>&1 || true
+
+run_once() { # -> prints elapsed milliseconds
+	local start end
+	start=$(python3 -c 'import time; print(time.time())')
+	"$GODOT" --headless --path "$PROJECT" -s -d --remote-debug tcp://127.0.0.1:0 \
+		res://addons/gdUnit4/bin/GdUnitCmdTool.gd -a "$FILTER" -c --ignoreHeadlessMode \
+		>/dev/null 2>&1 || true
+	end=$(python3 -c 'import time; print(time.time())')
+	python3 -c "print(int(($end - $start) * 1000))"
+}
+
+median() { # median of stdin numbers
+	sort -n | awk '{ a[NR]=$1 } END { if (NR%2) print a[(NR+1)/2]; else print int((a[NR/2]+a[NR/2+1])/2) }'
+}
+
+echo "Cold run (cache cleared) ..."
+rm -f "$CACHE_FILE"
+COLD=$(run_once)
+echo "  cold: ${COLD} ms"
+
+echo "Warm runs x$ITERATIONS ..."
+WARM_VALUES=""
+for i in $(seq 1 "$ITERATIONS"); do
+	ms=$(run_once)
+	echo "  warm $i/$ITERATIONS: ${ms} ms"
+	WARM_VALUES="$WARM_VALUES$ms
+"
+done
+WARM=$(printf '%s' "$WARM_VALUES" | median)
+
+echo
+echo "### GdUnit4 discovery-cache benchmark"
+echo
+echo "Project: \`$PROJECT\` | Godot: \`$("$GODOT" --version 2>/dev/null | head -1)\` | filter: \`$FILTER\`"
+echo
+echo "| Run | Wall clock |"
+echo "| --- | ---: |"
+echo "| Cold (cache cleared) | ${COLD} ms |"
+echo "| Warm (median of $ITERATIONS) | ${WARM} ms |"
+echo
+echo "Cache saves ~$((COLD - WARM)) ms per warm run (discovery cost removed)."


### PR DESCRIPTION
# Why

Resolves #1286.

Test discovery re-scans and reloads the whole project on every run, and nothing is cached between runs. Both the editor "Run All" (`GdUnitTestDiscoverer.run()`) and the command-line runner go through `GdUnitTestSuiteScanner`, which calls `ResourceLoader.load` on every candidate script to check `is_test_suite`, then runs `script.new()` and a `GdScriptParser` pass per suite.

On a project of 629 tests across 89 suites (Godot 4.7.1), that costs about 1.59 s on every run before any test executes, dominated by the per-script load (~1.18 s) rather than parsing (~0.37 s). The cost is constant on repeated runs even when no test file changed, and grows with the number of suites.

# What

Adds a persistent, file-modification-time keyed discovery cache. Unchanged files are served from the cache without loading their scripts; changed, new, or deleted files are re-discovered.

- **`GdUnitDiscoverCache`** — a JSON cache stored under `res://.godot/` (per-project, excluded from version control), keyed by `source_file` and its modification time, reusing `GdUnitTestCase.to_dict` / `from_dict`. Carries a format-version key so a stale cache is discarded rather than misread.
- **`GdUnitTestDiscoverer.discover_tests_cached()`** — a cache-aware walk (`collect_test_files` / `discover_file`) that enumerates candidate files without loading them, serves cache hits directly, discovers misses, prunes entries for deleted files, and syncs GUIDs from the previous session.
- **`GdUnitTestSuiteScanner.discover_suite_script()`** — a small public wrapper to load a single suite script.
- Both the editor discovery path and the command-line runner opt into the cache.
- A project setting **`settings/test/discovery_cache`** (default on) toggles it. On any cache miss, absent cache, or format-version mismatch, discovery falls back to the current full scan, so behaviour is never worse than before.
- Tests under `test/core/discovery/GdUnitDiscoverCacheTest.gd` (round-trip, hit/miss, version guard, pruning).
- A `benchmark/` harness that measures cold vs warm discovery on a target project.

Measured on the same 629-test / 89-suite project:

| Run | Discovery |
| --- | ---: |
| Cold (builds cache) | ~1580 ms |
| Warm | ~14 ms |

About 1.57 s saved per warm run, with the discovered totals tracking edits correctly (629 to 630 and back to 629 after a revert). No existing public method signatures change.

**Open design question (raised in #1286):** modification-time keying alone can miss a change when a parameterized test's parameter set is computed from another file that changes without the suite file's own modification time changing. The format-version key and the manual re-run cover the common cases; if maintainers prefer, this can be extended to dependency-aware invalidation, or the setting can default off. Happy to adjust the approach in place.

# Notes

- The setting defaults on for the out-of-the-box benefit; flipping the default to opt-in is a one-line change if preferred.
- Marked draft pending maintainer feedback on the invalidation strategy.
