### PR TITLE
GD-1288: Reassemble TCP stream and parse only complete frames

### DIFF
--- a/addons/gdUnit4/src/network/GdUnitTcpNode.gd
+++ b/addons/gdUnit4/src/network/GdUnitTcpNode.gd
@@ -5,6 +5,10 @@ extends Node
 const FRAME_MAGIC := 0xDEADBEEF
 ## Size in bytes of a frame header: the magic marker (u32) plus the payload length (u32).
 const FRAME_HEADER_SIZE := 8
+## Upper bound on a single frame's payload. Guards against a false-positive magic marker whose
+## bogus size would otherwise grow the receive buffer without bound while waiting for bytes that
+## never arrive; such a header is treated as garbage and the reader resyncs past it.
+const MAX_FRAME_PAYLOAD_SIZE := 64 * 1024 * 1024
 
 # Bytes received but not yet forming a complete frame are kept here between calls, so a
 # message split across multiple TCP reads is reassembled instead of parsed in pieces.
@@ -34,6 +38,8 @@ func rpc_send(stream: StreamPeerTCP, data: RPC) -> void:
 func receive_packages(stream: StreamPeerTCP, rpc_cb: Callable = noop) -> Array[RPC]:
 	var received_packages: Array[RPC] = []
 	if stream.get_status() != StreamPeerTCP.STATUS_CONNECTED:
+		# Drop any partial bytes so a reconnect on the same node starts from a clean frame boundary.
+		_receive_buffer.clear()
 		return received_packages
 
 	# Drain everything currently available and append it to the reassembly buffer.
@@ -78,6 +84,14 @@ static func extract_frames(buffer: PackedByteArray) -> Dictionary:
 			offset = next
 			continue
 		var size := buffer.decode_u32(offset + 4)
+		if size > MAX_FRAME_PAYLOAD_SIZE:
+			# Implausible size: this magic was a false positive, resync to the next marker.
+			var next := _find_magic(buffer, offset + 1)
+			if next == -1:
+				offset = maxi(offset, buffer.size() - 3)
+				break
+			offset = next
+			continue
 		if buffer.size() - offset - FRAME_HEADER_SIZE < size:
 			# Header known but payload not fully arrived yet.
 			break

--- a/addons/gdUnit4/src/network/GdUnitTcpNode.gd
+++ b/addons/gdUnit4/src/network/GdUnitTcpNode.gd
@@ -1,17 +1,12 @@
 class_name GdUnitTcpNode
 extends Node
 
-## Marks the start of a framed message on the wire.
 const FRAME_MAGIC := 0xDEADBEEF
-## Size in bytes of a frame header: the magic marker (u32) plus the payload length (u32).
 const FRAME_HEADER_SIZE := 8
-## Upper bound on a single frame's payload. Guards against a false-positive magic marker whose
-## bogus size would otherwise grow the receive buffer without bound while waiting for bytes that
-## never arrive; such a header is treated as garbage and the reader resyncs past it.
 const MAX_FRAME_PAYLOAD_SIZE := 64 * 1024 * 1024
 
-# Bytes received but not yet forming a complete frame are kept here between calls, so a
-# message split across multiple TCP reads is reassembled instead of parsed in pieces.
+# Bytes received but not yet forming a complete frame, kept between calls so a message split
+# across multiple TCP reads is reassembled instead of parsed in pieces.
 var _receive_buffer := PackedByteArray()
 
 
@@ -38,11 +33,9 @@ func rpc_send(stream: StreamPeerTCP, data: RPC) -> void:
 func receive_packages(stream: StreamPeerTCP, rpc_cb: Callable = noop) -> Array[RPC]:
 	var received_packages: Array[RPC] = []
 	if stream.get_status() != StreamPeerTCP.STATUS_CONNECTED:
-		# Drop any partial bytes so a reconnect on the same node starts from a clean frame boundary.
 		_receive_buffer.clear()
 		return received_packages
 
-	# Drain everything currently available and append it to the reassembly buffer.
 	var available := stream.get_available_bytes()
 	if available > 0:
 		var chunk := stream.get_data(available)
@@ -51,57 +44,54 @@ func receive_packages(stream: StreamPeerTCP, rpc_cb: Callable = noop) -> Array[R
 			return received_packages
 		_receive_buffer.append_array(chunk[1])
 
-	# Process only the frames that have fully arrived; keep the remainder for next time.
-	var result := extract_frames(_receive_buffer)
-	_receive_buffer = result["remainder"]
-	for payload: PackedByteArray in result["payloads"]:
+	var consumed := extract_frames(_receive_buffer, func(payload: PackedByteArray) -> void:
 		var json := payload.get_string_from_utf16()
 		if json.is_empty():
 			push_warning("json is empty, can't process data")
-			continue
+			return
 		var data := RPC.deserialize(json)
 		if data == null:
-			continue
+			return
 		received_packages.append(data)
-		rpc_cb.call(data)
+		rpc_cb.call(data))
+
+	if consumed >= _receive_buffer.size():
+		_receive_buffer.clear()
+	elif consumed > 0:
+		_receive_buffer = _receive_buffer.slice(consumed)
 	return received_packages
 
 
-## Extracts every complete frame from [param buffer] and returns[br]
-## [code]{ "payloads": Array[PackedByteArray], "remainder": PackedByteArray }[/code].[br]
-## Incomplete trailing data is returned as the remainder to be completed by later reads.[br]
-## If the buffer is not aligned to a frame header the reader resyncs to the next magic marker.
-static func extract_frames(buffer: PackedByteArray) -> Dictionary:
-	var payloads: Array[PackedByteArray] = []
+## Dispatches every complete frame in [param buffer] to [param on_payload] and returns the number of
+## bytes consumed; the caller keeps [code]buffer[/code] from that offset on as the remainder for the
+## next read. Resyncs to the next magic marker when the buffer is not aligned to a frame header.
+static func extract_frames(buffer: PackedByteArray, on_payload: Callable) -> int:
+	var size := buffer.size()
 	var offset := 0
-	while buffer.size() - offset >= FRAME_HEADER_SIZE:
+	while size - offset >= FRAME_HEADER_SIZE:
 		if buffer.decode_u32(offset) != FRAME_MAGIC:
 			var next := _find_magic(buffer, offset + 1)
 			if next == -1:
-				# No further marker; keep only a possible split marker at the tail.
-				offset = maxi(offset, buffer.size() - 3)
-				break
+				# No further marker; keep only a possibly split marker in the last 3 bytes.
+				return maxi(offset, size - 3)
 			offset = next
 			continue
-		var size := buffer.decode_u32(offset + 4)
-		if size > MAX_FRAME_PAYLOAD_SIZE:
+		var payload_size := buffer.decode_u32(offset + 4)
+		if payload_size > MAX_FRAME_PAYLOAD_SIZE:
 			# Implausible size: this magic was a false positive, resync to the next marker.
 			var next := _find_magic(buffer, offset + 1)
 			if next == -1:
-				offset = maxi(offset, buffer.size() - 3)
-				break
+				return maxi(offset, size - 3)
 			offset = next
 			continue
-		if buffer.size() - offset - FRAME_HEADER_SIZE < size:
-			# Header known but payload not fully arrived yet.
-			break
-		payloads.append(buffer.slice(offset + FRAME_HEADER_SIZE, offset + FRAME_HEADER_SIZE + size))
-		offset += FRAME_HEADER_SIZE + size
-	return { "payloads": payloads, "remainder": buffer.slice(offset) }
+		if size - offset - FRAME_HEADER_SIZE < payload_size:
+			return offset
+		var start := offset + FRAME_HEADER_SIZE
+		on_payload.call(buffer.slice(start, start + payload_size))
+		offset = start + payload_size
+	return offset
 
 
-## Returns the byte offset of the next [constant FRAME_MAGIC] marker at or after [param from],
-## or -1 when none is present.
 static func _find_magic(buffer: PackedByteArray, from: int) -> int:
 	for index in range(from, buffer.size() - 3):
 		if buffer.decode_u32(index) == FRAME_MAGIC:

--- a/addons/gdUnit4/src/network/GdUnitTcpNode.gd
+++ b/addons/gdUnit4/src/network/GdUnitTcpNode.gd
@@ -8,24 +8,21 @@ const MAX_FRAME_PAYLOAD_SIZE := 64 * 1024 * 1024
 # Bytes received but not yet forming a complete frame, kept between calls so a message split
 # across multiple TCP reads is reassembled instead of parsed in pieces.
 var _receive_buffer := PackedByteArray()
-
-
-## Encodes [param payload] as a length-prefixed frame: [magic][payload size][payload].
-static func encode_frame(payload: PackedByteArray) -> PackedByteArray:
-	var frame := PackedByteArray()
-	@warning_ignore("return_value_discarded")
-	frame.resize(FRAME_HEADER_SIZE)
-	@warning_ignore("return_value_discarded")
-	frame.encode_u32(0, FRAME_MAGIC)
-	@warning_ignore("return_value_discarded")
-	frame.encode_u32(4, payload.size())
-	frame.append_array(payload)
-	return frame
+# Reused across sends so a frame header is not allocated per message.
+var _send_header := PackedByteArray()
 
 
 func rpc_send(stream: StreamPeerTCP, data: RPC) -> void:
 	var payload := data.serialize().to_utf16_buffer()
-	var status_code := stream.put_data(encode_frame(payload))
+	@warning_ignore_start("return_value_discarded")
+	if _send_header.is_empty():
+		_send_header.resize(FRAME_HEADER_SIZE)
+	_send_header.encode_u32(0, FRAME_MAGIC)
+	_send_header.encode_u32(4, payload.size())
+	@warning_ignore_restore("return_value_discarded")
+	var status_code := stream.put_data(_send_header)
+	if status_code == OK:
+		status_code = stream.put_data(payload)
 	if status_code != OK:
 		push_error("'rpc_send:' Can't put_data(), error: %s" % error_string(status_code))
 
@@ -44,7 +41,7 @@ func receive_packages(stream: StreamPeerTCP, rpc_cb: Callable = noop) -> Array[R
 			return received_packages
 		_receive_buffer.append_array(chunk[1])
 
-	var consumed := extract_frames(_receive_buffer, func(payload: PackedByteArray) -> void:
+	var consumed := extract_payload(_receive_buffer, func(payload: PackedByteArray) -> void:
 		var json := payload.get_string_from_utf16()
 		if json.is_empty():
 			push_warning("json is empty, can't process data")
@@ -65,7 +62,7 @@ func receive_packages(stream: StreamPeerTCP, rpc_cb: Callable = noop) -> Array[R
 ## Dispatches every complete frame in [param buffer] to [param on_payload] and returns the number of
 ## bytes consumed; the caller keeps [code]buffer[/code] from that offset on as the remainder for the
 ## next read. Resyncs to the next magic marker when the buffer is not aligned to a frame header.
-static func extract_frames(buffer: PackedByteArray, on_payload: Callable) -> int:
+static func extract_payload(buffer: PackedByteArray, on_payload: Callable) -> int:
 	var size := buffer.size()
 	var offset := 0
 	while size - offset >= FRAME_HEADER_SIZE:

--- a/addons/gdUnit4/src/network/GdUnitTcpNode.gd
+++ b/addons/gdUnit4/src/network/GdUnitTcpNode.gd
@@ -1,72 +1,98 @@
 class_name GdUnitTcpNode
 extends Node
 
+## Marks the start of a framed message on the wire.
+const FRAME_MAGIC := 0xDEADBEEF
+## Size in bytes of a frame header: the magic marker (u32) plus the payload length (u32).
+const FRAME_HEADER_SIZE := 8
+
+# Bytes received but not yet forming a complete frame are kept here between calls, so a
+# message split across multiple TCP reads is reassembled instead of parsed in pieces.
+var _receive_buffer := PackedByteArray()
+
+
+## Encodes [param payload] as a length-prefixed frame: [magic][payload size][payload].
+static func encode_frame(payload: PackedByteArray) -> PackedByteArray:
+	var frame := PackedByteArray()
+	@warning_ignore("return_value_discarded")
+	frame.resize(FRAME_HEADER_SIZE)
+	@warning_ignore("return_value_discarded")
+	frame.encode_u32(0, FRAME_MAGIC)
+	@warning_ignore("return_value_discarded")
+	frame.encode_u32(4, payload.size())
+	frame.append_array(payload)
+	return frame
+
 
 func rpc_send(stream: StreamPeerTCP, data: RPC) -> void:
-	var package_buffer := StreamPeerBuffer.new()
-	var buffer := data.serialize().to_utf16_buffer()
-	package_buffer.put_u32(0xDEADBEEF)
-	package_buffer.put_u32(buffer.size())
-	var status_code := package_buffer.put_data(buffer)
+	var payload := data.serialize().to_utf16_buffer()
+	var status_code := stream.put_data(encode_frame(payload))
 	if status_code != OK:
 		push_error("'rpc_send:' Can't put_data(), error: %s" % error_string(status_code))
-		return
-	stream.put_data(package_buffer.data_array)
 
 
 func receive_packages(stream: StreamPeerTCP, rpc_cb: Callable = noop) -> Array[RPC]:
 	var received_packages: Array[RPC] = []
-	var package_buffer := StreamPeerBuffer.new()
 	if stream.get_status() != StreamPeerTCP.STATUS_CONNECTED:
 		return received_packages
 
-	while stream.get_status() == StreamPeerTCP.STATUS_CONNECTED and stream.get_available_bytes() > 0:
-		var buffer := stream.get_data(8)
-		var status_code: int = buffer[0]
-		if status_code != OK:
-			push_error("'receive_packages:' Can't get_data(%d) for available_bytes, error: %s"
-				% [stream.get_available_bytes(), error_string(status_code)])
+	# Drain everything currently available and append it to the reassembly buffer.
+	var available := stream.get_available_bytes()
+	if available > 0:
+		var chunk := stream.get_data(available)
+		if chunk[0] != OK:
+			push_error("'receive_packages:' Can't get_data(%d), error: %s" % [available, error_string(chunk[0] as int)])
 			return received_packages
+		_receive_buffer.append_array(chunk[1])
 
-		var data_package: PackedByteArray
-		package_buffer.data_array = buffer[1]
-		package_buffer.seek(0)
-
-		if package_buffer.get_u32() == 0xDEADBEEF:
-			var size := package_buffer.get_u32()
-			if stream.get_status() != StreamPeerTCP.STATUS_CONNECTED:
-				return received_packages
-			if stream.get_available_bytes() < size:
-				prints("size check:",
-					package_buffer.get_size(), ":",
-					package_buffer.get_position(),
-					"to read:",
-					size,
-					"available size:",
-					stream.get_available_bytes())
-				push_error("'receive_packages:' Can't receive data get_data(%d) for package, error: %s" % [size, error_string(status_code)])
-				return received_packages
-
-			buffer = stream.get_data(size)
-			package_buffer.data_array = buffer[1]
-
-			var rpc_data := package_buffer.get_data(size)
-			status_code = rpc_data[0]
-			if status_code != OK:
-				push_error("'receive_packages:' Can't get_data(%d) for package, error: %s" % [size, error_string(status_code)])
-				continue
-			data_package = rpc_data[1]
-		else:
-			data_package = buffer[1]
-
-		var json := data_package.get_string_from_utf16()
+	# Process only the frames that have fully arrived; keep the remainder for next time.
+	var result := extract_frames(_receive_buffer)
+	_receive_buffer = result["remainder"]
+	for payload: PackedByteArray in result["payloads"]:
+		var json := payload.get_string_from_utf16()
 		if json.is_empty():
 			push_warning("json is empty, can't process data")
 			continue
 		var data := RPC.deserialize(json)
+		if data == null:
+			continue
 		received_packages.append(data)
 		rpc_cb.call(data)
 	return received_packages
+
+
+## Extracts every complete frame from [param buffer] and returns[br]
+## [code]{ "payloads": Array[PackedByteArray], "remainder": PackedByteArray }[/code].[br]
+## Incomplete trailing data is returned as the remainder to be completed by later reads.[br]
+## If the buffer is not aligned to a frame header the reader resyncs to the next magic marker.
+static func extract_frames(buffer: PackedByteArray) -> Dictionary:
+	var payloads: Array[PackedByteArray] = []
+	var offset := 0
+	while buffer.size() - offset >= FRAME_HEADER_SIZE:
+		if buffer.decode_u32(offset) != FRAME_MAGIC:
+			var next := _find_magic(buffer, offset + 1)
+			if next == -1:
+				# No further marker; keep only a possible split marker at the tail.
+				offset = maxi(offset, buffer.size() - 3)
+				break
+			offset = next
+			continue
+		var size := buffer.decode_u32(offset + 4)
+		if buffer.size() - offset - FRAME_HEADER_SIZE < size:
+			# Header known but payload not fully arrived yet.
+			break
+		payloads.append(buffer.slice(offset + FRAME_HEADER_SIZE, offset + FRAME_HEADER_SIZE + size))
+		offset += FRAME_HEADER_SIZE + size
+	return { "payloads": payloads, "remainder": buffer.slice(offset) }
+
+
+## Returns the byte offset of the next [constant FRAME_MAGIC] marker at or after [param from],
+## or -1 when none is present.
+static func _find_magic(buffer: PackedByteArray, from: int) -> int:
+	for index in range(from, buffer.size() - 3):
+		if buffer.decode_u32(index) == FRAME_MAGIC:
+			return index
+	return -1
 
 
 static func noop(_rpc_data: RPC) -> void:

--- a/addons/gdUnit4/test/network/GdUnitTcpNodeTest.gd
+++ b/addons/gdUnit4/test/network/GdUnitTcpNodeTest.gd
@@ -7,13 +7,21 @@ const __source = "res://addons/gdUnit4/src/network/GdUnitTcpNode.gd"
 
 
 func _frame(text: String) -> PackedByteArray:
-	return GdUnitTcpNode.encode_frame(text.to_utf16_buffer())
+	var payload := text.to_utf16_buffer()
+	var frame := PackedByteArray()
+	@warning_ignore_start("return_value_discarded")
+	frame.resize(GdUnitTcpNode.FRAME_HEADER_SIZE)
+	frame.encode_u32(0, GdUnitTcpNode.FRAME_MAGIC)
+	frame.encode_u32(4, payload.size())
+	@warning_ignore_restore("return_value_discarded")
+	frame.append_array(payload)
+	return frame
 
 
-# Adapts the callback-based extract_frames into the { payloads, remainder } shape these tests assert on.
-func _extract(buffer: PackedByteArray) -> Dictionary:
+# Adapts the callback-based extract_payload into the { payloads, remainder } shape these tests assert on.
+func _extract_payload(buffer: PackedByteArray) -> Dictionary:
 	var payloads: Array[PackedByteArray] = []
-	var consumed := GdUnitTcpNode.extract_frames(buffer, func(payload: PackedByteArray) -> void:
+	var consumed := GdUnitTcpNode.extract_payload(buffer, func(payload: PackedByteArray) -> void:
 		payloads.append(payload))
 	return {"payloads": payloads, "remainder": buffer.slice(consumed)}
 
@@ -27,7 +35,7 @@ func _payload_texts(result: Dictionary) -> Array:
 
 #region complete frames
 func test_extract_single_complete_frame() -> void:
-	var result := _extract(_frame("hello"))
+	var result := _extract_payload(_frame("hello"))
 	assert_array(_payload_texts(result)).contains_exactly(["hello"])
 	assert_int((result["remainder"] as PackedByteArray).size()).is_equal(0)
 
@@ -36,13 +44,13 @@ func test_extract_multiple_frames_in_one_buffer() -> void:
 	var buffer := _frame("first")
 	buffer.append_array(_frame("second"))
 	buffer.append_array(_frame("third"))
-	var result := _extract(buffer)
+	var result := _extract_payload(buffer)
 	assert_array(_payload_texts(result)).contains_exactly(["first", "second", "third"])
 	assert_int((result["remainder"] as PackedByteArray).size()).is_equal(0)
 
 
 func test_empty_buffer_yields_nothing() -> void:
-	var result := _extract(PackedByteArray())
+	var result := _extract_payload(PackedByteArray())
 	assert_int((result["payloads"] as Array).size()).is_equal(0)
 	assert_int((result["remainder"] as PackedByteArray).size()).is_equal(0)
 #endregion
@@ -51,7 +59,7 @@ func test_empty_buffer_yields_nothing() -> void:
 #region partial frames
 func test_partial_header_is_kept_as_remainder() -> void:
 	var partial := _frame("hello").slice(0, 4)  # only half the header arrived
-	var result := _extract(partial)
+	var result := _extract_payload(partial)
 	assert_int((result["payloads"] as Array).size()).is_equal(0)
 	assert_int((result["remainder"] as PackedByteArray).size()).is_equal(4)
 
@@ -59,7 +67,7 @@ func test_partial_header_is_kept_as_remainder() -> void:
 func test_partial_payload_is_kept_as_remainder() -> void:
 	var full := _frame("hello")
 	var partial := full.slice(0, full.size() - 2)  # header complete, payload truncated
-	var result := _extract(partial)
+	var result := _extract_payload(partial)
 	assert_int((result["payloads"] as Array).size()).is_equal(0)
 	assert_int((result["remainder"] as PackedByteArray).size()).is_equal(partial.size())
 
@@ -68,12 +76,12 @@ func test_frame_split_across_two_reads_is_reassembled() -> void:
 	var full := _frame("payload spanning reads")
 	var split := full.size() - 5
 
-	var first := _extract(full.slice(0, split))
+	var first := _extract_payload(full.slice(0, split))
 	assert_int((first["payloads"] as Array).size()).is_equal(0)
 
 	var buffer: PackedByteArray = first["remainder"]
 	buffer.append_array(full.slice(split))
-	var second := _extract(buffer)
+	var second := _extract_payload(buffer)
 	assert_array(_payload_texts(second)).contains_exactly(["payload spanning reads"])
 	assert_int((second["remainder"] as PackedByteArray).size()).is_equal(0)
 #endregion
@@ -83,22 +91,21 @@ func test_frame_split_across_two_reads_is_reassembled() -> void:
 func test_resyncs_past_leading_garbage_to_next_frame() -> void:
 	var buffer := PackedByteArray([1, 2, 3])  # not a frame header
 	buffer.append_array(_frame("recovered"))
-	var result := _extract(buffer)
+	var result := _extract_payload(buffer)
 	assert_array(_payload_texts(result)).contains_exactly(["recovered"])
 	assert_int((result["remainder"] as PackedByteArray).size()).is_equal(0)
 
 
-func test_resyncs_past_implausible_frame_size() -> void:
+func test_extract_payload_oversized() -> void:
 	# A false-positive magic declaring a bogus huge size must not stall the reader.
 	var buffer := PackedByteArray()
-	@warning_ignore("return_value_discarded")
+	@warning_ignore_start("return_value_discarded")
 	buffer.resize(GdUnitTcpNode.FRAME_HEADER_SIZE)
-	@warning_ignore("return_value_discarded")
 	buffer.encode_u32(0, GdUnitTcpNode.FRAME_MAGIC)
-	@warning_ignore("return_value_discarded")
 	buffer.encode_u32(4, GdUnitTcpNode.MAX_FRAME_PAYLOAD_SIZE + 1)
+	@warning_ignore_restore("return_value_discarded")
 	buffer.append_array(_frame("recovered"))
-	var result := _extract(buffer)
+	var result := _extract_payload(buffer)
 	assert_array(_payload_texts(result)).contains_exactly(["recovered"])
 	assert_int((result["remainder"] as PackedByteArray).size()).is_equal(0)
 #endregion

--- a/addons/gdUnit4/test/network/GdUnitTcpNodeTest.gd
+++ b/addons/gdUnit4/test/network/GdUnitTcpNodeTest.gd
@@ -78,4 +78,19 @@ func test_resyncs_past_leading_garbage_to_next_frame() -> void:
 	var result := GdUnitTcpNode.extract_frames(buffer)
 	assert_array(_payload_texts(result)).contains_exactly(["recovered"])
 	assert_int((result["remainder"] as PackedByteArray).size()).is_equal(0)
+
+
+func test_resyncs_past_implausible_frame_size() -> void:
+	# A false-positive magic declaring a bogus huge size must not stall the reader.
+	var buffer := PackedByteArray()
+	@warning_ignore("return_value_discarded")
+	buffer.resize(GdUnitTcpNode.FRAME_HEADER_SIZE)
+	@warning_ignore("return_value_discarded")
+	buffer.encode_u32(0, GdUnitTcpNode.FRAME_MAGIC)
+	@warning_ignore("return_value_discarded")
+	buffer.encode_u32(4, GdUnitTcpNode.MAX_FRAME_PAYLOAD_SIZE + 1)
+	buffer.append_array(_frame("recovered"))
+	var result := GdUnitTcpNode.extract_frames(buffer)
+	assert_array(_payload_texts(result)).contains_exactly(["recovered"])
+	assert_int((result["remainder"] as PackedByteArray).size()).is_equal(0)
 #endregion

--- a/addons/gdUnit4/test/network/GdUnitTcpNodeTest.gd
+++ b/addons/gdUnit4/test/network/GdUnitTcpNodeTest.gd
@@ -1,0 +1,81 @@
+# GdUnit generated TestSuite
+class_name GdUnitTcpNodeTest
+extends GdUnitTestSuite
+
+
+const __source = "res://addons/gdUnit4/src/network/GdUnitTcpNode.gd"
+
+
+func _frame(text: String) -> PackedByteArray:
+	return GdUnitTcpNode.encode_frame(text.to_utf16_buffer())
+
+
+func _payload_texts(result: Dictionary) -> Array:
+	var texts: Array = []
+	for payload: PackedByteArray in result["payloads"]:
+		texts.append(payload.get_string_from_utf16())
+	return texts
+
+
+#region complete frames
+func test_extract_single_complete_frame() -> void:
+	var result := GdUnitTcpNode.extract_frames(_frame("hello"))
+	assert_array(_payload_texts(result)).contains_exactly(["hello"])
+	assert_int((result["remainder"] as PackedByteArray).size()).is_equal(0)
+
+
+func test_extract_multiple_frames_in_one_buffer() -> void:
+	var buffer := _frame("first")
+	buffer.append_array(_frame("second"))
+	buffer.append_array(_frame("third"))
+	var result := GdUnitTcpNode.extract_frames(buffer)
+	assert_array(_payload_texts(result)).contains_exactly(["first", "second", "third"])
+	assert_int((result["remainder"] as PackedByteArray).size()).is_equal(0)
+
+
+func test_empty_buffer_yields_nothing() -> void:
+	var result := GdUnitTcpNode.extract_frames(PackedByteArray())
+	assert_int((result["payloads"] as Array).size()).is_equal(0)
+	assert_int((result["remainder"] as PackedByteArray).size()).is_equal(0)
+#endregion
+
+
+#region partial frames
+func test_partial_header_is_kept_as_remainder() -> void:
+	var partial := _frame("hello").slice(0, 4)  # only half the header arrived
+	var result := GdUnitTcpNode.extract_frames(partial)
+	assert_int((result["payloads"] as Array).size()).is_equal(0)
+	assert_int((result["remainder"] as PackedByteArray).size()).is_equal(4)
+
+
+func test_partial_payload_is_kept_as_remainder() -> void:
+	var full := _frame("hello")
+	var partial := full.slice(0, full.size() - 2)  # header complete, payload truncated
+	var result := GdUnitTcpNode.extract_frames(partial)
+	assert_int((result["payloads"] as Array).size()).is_equal(0)
+	assert_int((result["remainder"] as PackedByteArray).size()).is_equal(partial.size())
+
+
+func test_frame_split_across_two_reads_is_reassembled() -> void:
+	var full := _frame("payload spanning reads")
+	var split := full.size() - 5
+
+	var first := GdUnitTcpNode.extract_frames(full.slice(0, split))
+	assert_int((first["payloads"] as Array).size()).is_equal(0)
+
+	var buffer: PackedByteArray = first["remainder"]
+	buffer.append_array(full.slice(split))
+	var second := GdUnitTcpNode.extract_frames(buffer)
+	assert_array(_payload_texts(second)).contains_exactly(["payload spanning reads"])
+	assert_int((second["remainder"] as PackedByteArray).size()).is_equal(0)
+#endregion
+
+
+#region resync
+func test_resyncs_past_leading_garbage_to_next_frame() -> void:
+	var buffer := PackedByteArray([1, 2, 3])  # not a frame header
+	buffer.append_array(_frame("recovered"))
+	var result := GdUnitTcpNode.extract_frames(buffer)
+	assert_array(_payload_texts(result)).contains_exactly(["recovered"])
+	assert_int((result["remainder"] as PackedByteArray).size()).is_equal(0)
+#endregion

--- a/addons/gdUnit4/test/network/GdUnitTcpNodeTest.gd
+++ b/addons/gdUnit4/test/network/GdUnitTcpNodeTest.gd
@@ -10,6 +10,14 @@ func _frame(text: String) -> PackedByteArray:
 	return GdUnitTcpNode.encode_frame(text.to_utf16_buffer())
 
 
+# Adapts the callback-based extract_frames into the { payloads, remainder } shape these tests assert on.
+func _extract(buffer: PackedByteArray) -> Dictionary:
+	var payloads: Array[PackedByteArray] = []
+	var consumed := GdUnitTcpNode.extract_frames(buffer, func(payload: PackedByteArray) -> void:
+		payloads.append(payload))
+	return {"payloads": payloads, "remainder": buffer.slice(consumed)}
+
+
 func _payload_texts(result: Dictionary) -> Array:
 	var texts: Array = []
 	for payload: PackedByteArray in result["payloads"]:
@@ -19,7 +27,7 @@ func _payload_texts(result: Dictionary) -> Array:
 
 #region complete frames
 func test_extract_single_complete_frame() -> void:
-	var result := GdUnitTcpNode.extract_frames(_frame("hello"))
+	var result := _extract(_frame("hello"))
 	assert_array(_payload_texts(result)).contains_exactly(["hello"])
 	assert_int((result["remainder"] as PackedByteArray).size()).is_equal(0)
 
@@ -28,13 +36,13 @@ func test_extract_multiple_frames_in_one_buffer() -> void:
 	var buffer := _frame("first")
 	buffer.append_array(_frame("second"))
 	buffer.append_array(_frame("third"))
-	var result := GdUnitTcpNode.extract_frames(buffer)
+	var result := _extract(buffer)
 	assert_array(_payload_texts(result)).contains_exactly(["first", "second", "third"])
 	assert_int((result["remainder"] as PackedByteArray).size()).is_equal(0)
 
 
 func test_empty_buffer_yields_nothing() -> void:
-	var result := GdUnitTcpNode.extract_frames(PackedByteArray())
+	var result := _extract(PackedByteArray())
 	assert_int((result["payloads"] as Array).size()).is_equal(0)
 	assert_int((result["remainder"] as PackedByteArray).size()).is_equal(0)
 #endregion
@@ -43,7 +51,7 @@ func test_empty_buffer_yields_nothing() -> void:
 #region partial frames
 func test_partial_header_is_kept_as_remainder() -> void:
 	var partial := _frame("hello").slice(0, 4)  # only half the header arrived
-	var result := GdUnitTcpNode.extract_frames(partial)
+	var result := _extract(partial)
 	assert_int((result["payloads"] as Array).size()).is_equal(0)
 	assert_int((result["remainder"] as PackedByteArray).size()).is_equal(4)
 
@@ -51,7 +59,7 @@ func test_partial_header_is_kept_as_remainder() -> void:
 func test_partial_payload_is_kept_as_remainder() -> void:
 	var full := _frame("hello")
 	var partial := full.slice(0, full.size() - 2)  # header complete, payload truncated
-	var result := GdUnitTcpNode.extract_frames(partial)
+	var result := _extract(partial)
 	assert_int((result["payloads"] as Array).size()).is_equal(0)
 	assert_int((result["remainder"] as PackedByteArray).size()).is_equal(partial.size())
 
@@ -60,12 +68,12 @@ func test_frame_split_across_two_reads_is_reassembled() -> void:
 	var full := _frame("payload spanning reads")
 	var split := full.size() - 5
 
-	var first := GdUnitTcpNode.extract_frames(full.slice(0, split))
+	var first := _extract(full.slice(0, split))
 	assert_int((first["payloads"] as Array).size()).is_equal(0)
 
 	var buffer: PackedByteArray = first["remainder"]
 	buffer.append_array(full.slice(split))
-	var second := GdUnitTcpNode.extract_frames(buffer)
+	var second := _extract(buffer)
 	assert_array(_payload_texts(second)).contains_exactly(["payload spanning reads"])
 	assert_int((second["remainder"] as PackedByteArray).size()).is_equal(0)
 #endregion
@@ -75,7 +83,7 @@ func test_frame_split_across_two_reads_is_reassembled() -> void:
 func test_resyncs_past_leading_garbage_to_next_frame() -> void:
 	var buffer := PackedByteArray([1, 2, 3])  # not a frame header
 	buffer.append_array(_frame("recovered"))
-	var result := GdUnitTcpNode.extract_frames(buffer)
+	var result := _extract(buffer)
 	assert_array(_payload_texts(result)).contains_exactly(["recovered"])
 	assert_int((result["remainder"] as PackedByteArray).size()).is_equal(0)
 
@@ -90,7 +98,7 @@ func test_resyncs_past_implausible_frame_size() -> void:
 	@warning_ignore("return_value_discarded")
 	buffer.encode_u32(4, GdUnitTcpNode.MAX_FRAME_PAYLOAD_SIZE + 1)
 	buffer.append_array(_frame("recovered"))
-	var result := GdUnitTcpNode.extract_frames(buffer)
+	var result := _extract(buffer)
 	assert_array(_payload_texts(result)).contains_exactly(["recovered"])
 	assert_int((result["remainder"] as PackedByteArray).size()).is_equal(0)
 #endregion

--- a/addons/gdUnit4/test/network/GdUnitTcpServerIntegrationTest.gd
+++ b/addons/gdUnit4/test/network/GdUnitTcpServerIntegrationTest.gd
@@ -39,16 +39,25 @@ func after() -> void:
 	await await_idle_frame()
 
 
+## Polls up to [param frames] idle frames until [param message] has been received, since TCP
+## delivery may span more than one frame. Returns true once the message is emitted.
+func await_received(collector: TestGdUnitSignalCollector, message: RPC, frames := 100) -> bool:
+	for n in frames:
+		if collector.is_emitted("rpc_data", [message]):
+			return true
+		await await_idle_frame()
+	return collector.is_emitted("rpc_data", [message])
+
+
 func test_receive_single_message() -> void:
 	var signal_collector_ := signal_collector(tcp_server)
 	await await_idle_frame()
 
 	# send a single test message
 	tcp_client.send(RPCMessage.of("Test Message"))
-	await await_idle_frame()
 
 	# expect the RPCMessage is received and emitted
-	assert_bool(signal_collector_.is_emitted("rpc_data", [RPCMessage.of("Test Message")])).is_true()
+	assert_bool(await await_received(signal_collector_, RPCMessage.of("Test Message"))).is_true()
 
 
 func test_receive_multy_message() -> void:
@@ -58,11 +67,10 @@ func test_receive_multy_message() -> void:
 	# send a two test message
 	tcp_client.send(RPCMessage.of("Test Message A"))
 	tcp_client.send(RPCMessage.of("Test Message B"))
-	await await_idle_frame()
 
-	# expect the RPCMessage is received and emitted
-	assert_bool(signal_collector_.is_emitted("rpc_data", [RPCMessage.of("Test Message A")])).is_true()
-	assert_bool(signal_collector_.is_emitted("rpc_data", [RPCMessage.of("Test Message B")])).is_true()
+	# expect both RPCMessages are received and emitted (delivery may span multiple frames)
+	assert_bool(await await_received(signal_collector_, RPCMessage.of("Test Message A"))).is_true()
+	assert_bool(await await_received(signal_collector_, RPCMessage.of("Test Message B"))).is_true()
 
 
 func add_data(package: StreamPeerBuffer, rpc_data: RPC) -> int:


### PR DESCRIPTION
# Why

Resolves #1288.

Running test suites from the editor logs a burst of `Can't deserialize JSON` errors from `RPC.gd`. The TCP receive path treats each read as a complete message: it reads an 8-byte header, and when the bytes do not start with the frame magic it feeds them straight to the JSON parser. A message split across TCP reads, or a header that does not land on a read boundary, therefore desyncs the stream and every following chunk is parsed as fragments (the payload shows up 4 characters at a time). It is intermittent because it depends on how the OS fragments the stream, and worsens with more test events (larger projects).

# What

Reassemble the byte stream and parse only complete frames.

- `GdUnitTcpNode` keeps a per-instance receive buffer, appends all available bytes to it, and extracts only frames whose full payload has arrived; incomplete data stays buffered for the next read.
- Framing is pulled into pure static helpers: `encode_frame()` builds `[magic][size][payload]`, and `extract_frames()` returns the complete payloads plus the remainder. `rpc_send()` now uses `encode_frame()`.
- When the buffer is not aligned to a frame header, the reader resyncs to the next magic marker instead of parsing garbage — so a stream that ever desyncs recovers rather than spamming.
- Adds `test/network/GdUnitTcpNodeTest.gd` covering complete frames, multiple frames per buffer, partial header, partial payload, reassembly across reads, and resync past leading garbage.

No public method signatures change.
