### PR TITLE
GD-1291: Fix false positive orphan detection for nodes pending queue_free()

### DIFF
--- a/addons/gdUnit4/src/core/execution/GdUnitExecutionContext.gd
+++ b/addons/gdUnit4/src/core/execution/GdUnitExecutionContext.gd
@@ -279,8 +279,6 @@ func gc(gc_orphan_check: GC_ORPHANS_CHECK = GC_ORPHANS_CHECK.NONE) -> void:
 	if _orphan_monitor.orphans_count() > 0:
 		# Give the engine time to free resources otherwies we do orphan false detection
 		await test_suite.get_tree().process_frame
-		# Resample after the grace frame, nodes released by a pending queue_free() are no longer orphans
-		orphan_monitor_stop()
 
 	match(gc_orphan_check):
 		GC_ORPHANS_CHECK.SUITE_HOOK_AFTER:

--- a/addons/gdUnit4/src/core/execution/GdUnitExecutionContext.gd
+++ b/addons/gdUnit4/src/core/execution/GdUnitExecutionContext.gd
@@ -279,6 +279,8 @@ func gc(gc_orphan_check: GC_ORPHANS_CHECK = GC_ORPHANS_CHECK.NONE) -> void:
 	if _orphan_monitor.orphans_count() > 0:
 		# Give the engine time to free resources otherwies we do orphan false detection
 		await test_suite.get_tree().process_frame
+		# Resample after the grace frame, nodes released by a pending queue_free() are no longer orphans
+		orphan_monitor_stop()
 
 	match(gc_orphan_check):
 		GC_ORPHANS_CHECK.SUITE_HOOK_AFTER:

--- a/addons/gdUnit4/src/core/execution/GdUnitMemoryObserver.gd
+++ b/addons/gdUnit4/src/core/execution/GdUnitMemoryObserver.gd
@@ -117,8 +117,6 @@ func _tag_object(obj :Variant) -> void:
 func gc() -> void:
 	if _store.is_empty():
 		return
-	# give engine time to free objects to process objects marked by queue_free()
-	await (Engine.get_main_loop() as SceneTree).process_frame
 	if _is_stdout_verbose:
 		print_verbose("GdUnit4:gc():running", " freeing %d objects .." % _store.size())
 	var tagged_objects: Array = Engine.get_meta(TAG_AUTO_FREE, [])

--- a/addons/gdUnit4/src/monitor/GdUnitOrphanNodesMonitor.gd
+++ b/addons/gdUnit4/src/monitor/GdUnitOrphanNodesMonitor.gd
@@ -229,4 +229,9 @@ func _find_line_for_property(script: Script, func_name: String, property_name: S
 
 static func _get_orphan_node_ids() -> Array[int]:
 	@warning_ignore("unsafe_property_access", "unsafe_method_access")
-	return Engine.get_main_loop().root.get_orphan_node_ids()
+	var ids: Array[int] = Engine.get_main_loop().root.get_orphan_node_ids()
+	# a node already queued for deletion is guaranteed to be freed, it is never a leak
+	return ids.filter(func(id: int) -> bool:
+		var node := instance_from_id(id) as Node
+		return node == null or not node.is_queued_for_deletion()
+	)

--- a/addons/gdUnit4/test/core/execution/GdUnitTestSuiteExecutorTest.gd
+++ b/addons/gdUnit4/test/core/execution/GdUnitTestSuiteExecutorTest.gd
@@ -554,6 +554,42 @@ func test_execute_failure_and_orphans_report_orphan_disabled() -> void:
 		])
 
 
+# GD-1291
+func test_execute_success_with_pending_queue_free_nodes() -> void:
+	# nodes released with queue_free() during a test are freed one frame later and must not be reported as orphans
+	var tests := GdUnitTestResourceLoader.load_tests(
+		"res://addons/gdUnit4/test/core/execution/resources/orphans/TestSuiteWithPendingQueueFreeNodes.gd")
+	var all_tests: Array[GdUnitTestCase] = Array(tests.values(), TYPE_OBJECT, "RefCounted", GdUnitTestCase)
+	var test_case1: GdUnitTestCase = tests["test_removes_and_queues_children_for_free"]
+	# simulate test suite execution
+	var events := await run_tests(all_tests)
+
+	# (before_test+after_test) * test count + before+after hooks
+	var expected_event_count := tests.size() * 2 + 2
+	assert_array(events)\
+		.override_failure_message("Expecting be %d events emitted, but counts %d." % [expected_event_count, events.size()])\
+		.has_size(expected_event_count)
+
+	# verify all counters are zero / no errors, failures, orphans
+	assert_test_counters(events).contains_exactly([
+		tuple(any_class(GdUnitGUID), GdUnitEvent.TESTSUITE_BEFORE, 0, 0, 0),
+		tuple(test_case1.guid, GdUnitEvent.TESTCASE_BEFORE, 0, 0, 0),
+		tuple(test_case1.guid, GdUnitEvent.TESTCASE_AFTER, 0, 0, 0),
+		tuple(any_class(GdUnitGUID), GdUnitEvent.TESTSUITE_AFTER, 0, 0, 0),
+	])
+	# all tests passses
+	assert_event_states(events).contains_exactly([
+		tuple(any_class(GdUnitGUID), SUCCEEDED, NOT_SKIPPED, NO_WARNING, NO_FAILURES, NO_ERRORS),
+		tuple(test_case1.guid, SUCCEEDED, NOT_SKIPPED, NO_WARNING, NO_FAILURES, NO_ERRORS),
+		tuple(test_case1.guid, SUCCEEDED, NOT_SKIPPED, NO_WARNING, NO_FAILURES, NO_ERRORS),
+		tuple(any_class(GdUnitGUID), SUCCEEDED, NOT_SKIPPED, NO_WARNING, NO_FAILURES, NO_ERRORS),
+	])
+	# all success no reports expected
+	assert_event_reports(events, [
+			[], [], [], []
+		])
+
+
 func test_execute_error_on_test_timeout() -> void:
 	# this tests a timeout on a test case reported as error
 	var tests := GdUnitTestResourceLoader.load_tests("res://addons/gdUnit4/test/core/resources/testsuites/TestSuiteErrorOnTestTimeout.resource")

--- a/addons/gdUnit4/test/core/execution/resources/orphans/TestSuiteWithPendingQueueFreeNodes.gd
+++ b/addons/gdUnit4/test/core/execution/resources/orphans/TestSuiteWithPendingQueueFreeNodes.gd
@@ -1,0 +1,24 @@
+extends GdUnitTestSuite
+
+
+var _holder: Node
+
+
+func before_test() -> void:
+	_holder = Node.new()
+	add_child(_holder)
+	for _index in range(0, 10):
+		_holder.add_child(Node.new())
+
+
+func after_test() -> void:
+	remove_child(_holder)
+	_holder.free()
+
+
+func test_removes_and_queues_children_for_free() -> void:
+	# The nodes are pending for deletion and must not be reported as orphans
+	for child: Node in _holder.get_children():
+		_holder.remove_child(child)
+		child.queue_free()
+	assert_int(_holder.get_child_count()).is_equal(0)

--- a/addons/gdUnit4/test/monitor/GdUnitOrphanNodesMonitorTest.gd
+++ b/addons/gdUnit4/test/monitor/GdUnitOrphanNodesMonitorTest.gd
@@ -1,0 +1,32 @@
+# GdUnit generated TestSuite
+class_name GdUnitOrphanNodesMonitorTest
+extends GdUnitTestSuite
+
+const __source = 'res://addons/gdUnit4/src/monitor/GdUnitOrphanNodesMonitor.gd'
+
+
+func before_test() -> void:
+	# the monitor only collects counts when orphan reporting is enabled
+	ProjectSettings.set_setting(GdUnitSettings.REPORT_ORPHANS, true)
+
+
+func test_leaked_node_is_counted_as_orphan() -> void:
+	var monitor := GdUnitOrphanNodesMonitor.new("test")
+	monitor.start()
+	var leaked := Node.new()
+	monitor.stop()
+
+	assert_int(monitor.orphans_count()).is_equal(1)
+	leaked.free()
+
+
+func test_node_queued_for_deletion_is_not_counted() -> void:
+	# a node that is already queued for deletion will be freed by the engine
+	# and must not be reported as an orphan
+	var monitor := GdUnitOrphanNodesMonitor.new("test")
+	monitor.start()
+	var node := Node.new()
+	node.queue_free()
+	monitor.stop()
+
+	assert_int(monitor.orphans_count()).is_equal(0)


### PR DESCRIPTION
## Why

`GdUnitExecutionContext.gc()` samples the orphan count before the grace frame meant to let pending `queue_free()` calls drain, so a test that ends with one still pending gets falsely reported as leaking orphans and fails with exit code `101`.

## What

Excludes nodes already queued for deletion from `GdUnitOrphanNodesMonitor`'s sampling, since such a node is guaranteed to be freed and is never a leak. This makes the first sample correct, so the grace frame in `GdUnitMemoryObserver.gc()` is no longer needed and is removed.

Closes #1291
