### PR TITLE
GD-1288: Fixing `GdUnitTcpNode` to reassemble split TCP frames

### DIFF
--- a/addons/gdUnit4/src/core/execution/GdUnitExecutionContext.gd
+++ b/addons/gdUnit4/src/core/execution/GdUnitExecutionContext.gd
@@ -182,6 +182,9 @@ func last_error() -> GdUnitError:
 	if  _last_error != null:
 		return _last_error
 
+	if _report_collector.reports().is_empty():
+		return null
+
 	var last_report: GdUnitReport = _report_collector.reports()[-1]
 	return last_report._error if last_report != null else _last_error
 

--- a/addons/gdUnit4/src/network/GdUnitTcpNode.gd
+++ b/addons/gdUnit4/src/network/GdUnitTcpNode.gd
@@ -1,69 +1,51 @@
 class_name GdUnitTcpNode
 extends Node
 
+## Maximum size of a single RPC payload. Godot's default of 64 KiB is too small for larger test
+## events (e.g. reports with long stack traces), so it is raised here. Kept modest because
+## `PacketPeerStream` allocates its buffers eagerly at this size, per connection.
+const MAX_PACKET_SIZE := 2 * 1024 * 1024
+
+# `PacketPeerStream` reassembles length-prefixed packets from a raw `StreamPeerTCP` byte stream,
+# buffering partial reads across calls instead of assuming a full message always arrives at once.
+var _packets := _new_packet_peer()
+
+
+static func _new_packet_peer() -> PacketPeerStream:
+	var packet_peer := PacketPeerStream.new()
+	packet_peer.input_buffer_max_size = MAX_PACKET_SIZE
+	packet_peer.output_buffer_max_size = MAX_PACKET_SIZE
+	return packet_peer
+
 
 func rpc_send(stream: StreamPeerTCP, data: RPC) -> void:
-	var package_buffer := StreamPeerBuffer.new()
-	var buffer := data.serialize().to_utf16_buffer()
-	package_buffer.put_u32(0xDEADBEEF)
-	package_buffer.put_u32(buffer.size())
-	var status_code := package_buffer.put_data(buffer)
+	_packets.stream_peer = stream
+	var payload := data.serialize().to_utf16_buffer()
+	var status_code := _packets.put_packet(payload)
 	if status_code != OK:
-		push_error("'rpc_send:' Can't put_data(), error: %s" % error_string(status_code))
-		return
-	stream.put_data(package_buffer.data_array)
+		push_error("'rpc_send:' Can't put_packet(), error: %s" % error_string(status_code))
 
 
 func receive_packages(stream: StreamPeerTCP, rpc_cb: Callable = noop) -> Array[RPC]:
 	var received_packages: Array[RPC] = []
-	var package_buffer := StreamPeerBuffer.new()
 	if stream.get_status() != StreamPeerTCP.STATUS_CONNECTED:
 		return received_packages
 
-	while stream.get_status() == StreamPeerTCP.STATUS_CONNECTED and stream.get_available_bytes() > 0:
-		var buffer := stream.get_data(8)
-		var status_code: int = buffer[0]
+	_packets.stream_peer = stream
+	while _packets.get_available_packet_count() > 0:
+		var payload := _packets.get_packet()
+		var status_code := _packets.get_packet_error()
 		if status_code != OK:
-			push_error("'receive_packages:' Can't get_data(%d) for available_bytes, error: %s"
-				% [stream.get_available_bytes(), error_string(status_code)])
-			return received_packages
+			push_error("'receive_packages:' Can't get_packet(), error: %s" % error_string(status_code))
+			continue
 
-		var data_package: PackedByteArray
-		package_buffer.data_array = buffer[1]
-		package_buffer.seek(0)
-
-		if package_buffer.get_u32() == 0xDEADBEEF:
-			var size := package_buffer.get_u32()
-			if stream.get_status() != StreamPeerTCP.STATUS_CONNECTED:
-				return received_packages
-			if stream.get_available_bytes() < size:
-				prints("size check:",
-					package_buffer.get_size(), ":",
-					package_buffer.get_position(),
-					"to read:",
-					size,
-					"available size:",
-					stream.get_available_bytes())
-				push_error("'receive_packages:' Can't receive data get_data(%d) for package, error: %s" % [size, error_string(status_code)])
-				return received_packages
-
-			buffer = stream.get_data(size)
-			package_buffer.data_array = buffer[1]
-
-			var rpc_data := package_buffer.get_data(size)
-			status_code = rpc_data[0]
-			if status_code != OK:
-				push_error("'receive_packages:' Can't get_data(%d) for package, error: %s" % [size, error_string(status_code)])
-				continue
-			data_package = rpc_data[1]
-		else:
-			data_package = buffer[1]
-
-		var json := data_package.get_string_from_utf16()
+		var json := payload.get_string_from_utf16()
 		if json.is_empty():
 			push_warning("json is empty, can't process data")
 			continue
 		var data := RPC.deserialize(json)
+		if data == null:
+			continue
 		received_packages.append(data)
 		rpc_cb.call(data)
 	return received_packages

--- a/addons/gdUnit4/src/network/GdUnitTcpServer.gd
+++ b/addons/gdUnit4/src/network/GdUnitTcpServer.gd
@@ -29,7 +29,7 @@ class TcpConnection extends GdUnitTcpNode:
 	func close() -> void:
 		if _stream != null and _stream.get_status() == StreamPeerTCP.STATUS_CONNECTED:
 			_stream.disconnect_from_host()
-			queue_free()
+		queue_free()
 
 
 	func id() -> int:

--- a/addons/gdUnit4/test/network/GdUnitTcpServerIntegrationTest.gd
+++ b/addons/gdUnit4/test/network/GdUnitTcpServerIntegrationTest.gd
@@ -6,6 +6,7 @@ const __source = 'res://addons/gdUnit4/src/network/GdUnitTcpServer.gd'
 
 var tcp_server: GdUnitTcpServer
 var tcp_client: GdUnitTcpClient
+var server_port: int
 
 
 ## We start a custom test server for this suite
@@ -19,7 +20,7 @@ func before() -> void:
 	if not result.is_success():
 		return
 
-	var server_port: int = result.value()
+	server_port = result.value()
 	tcp_client.start("127.0.0.1", server_port)
 
 	# wait until the client is connected
@@ -39,62 +40,70 @@ func after() -> void:
 	await await_idle_frame()
 
 
-func test_receive_single_message() -> void:
-	var signal_collector_ := signal_collector(tcp_server)
-	await await_idle_frame()
+@warning_ignore_start("redundant_await")
+func test_receive_single_message(_timeout := 1000) -> void:
+	monitor_signals(tcp_server, false)
 
 	# send a single test message
 	tcp_client.send(RPCMessage.of("Test Message"))
-	await await_idle_frame()
 
 	# expect the RPCMessage is received and emitted
-	assert_bool(signal_collector_.is_emitted("rpc_data", [RPCMessage.of("Test Message")])).is_true()
+	await assert_signal(tcp_server).is_emitted("rpc_data", RPCMessage.of("Test Message"))
 
 
-func test_receive_multy_message() -> void:
-	var signal_collector_ := signal_collector(tcp_server)
-	await await_idle_frame()
+func test_receive_multy_message(_timeout := 1000) -> void:
+	monitor_signals(tcp_server, false)
 
 	# send a two test message
 	tcp_client.send(RPCMessage.of("Test Message A"))
 	tcp_client.send(RPCMessage.of("Test Message B"))
-	await await_idle_frame()
 
 	# expect the RPCMessage is received and emitted
-	assert_bool(signal_collector_.is_emitted("rpc_data", [RPCMessage.of("Test Message A")])).is_true()
-	assert_bool(signal_collector_.is_emitted("rpc_data", [RPCMessage.of("Test Message B")])).is_true()
+	await assert_signal(tcp_server).is_emitted("rpc_data", RPCMessage.of("Test Message A"))
+	await assert_signal(tcp_server).is_emitted("rpc_data", RPCMessage.of("Test Message B"))
 
 
-func add_data(package: StreamPeerBuffer, rpc_data: RPC) -> int:
-	var buffer := rpc_data.serialize().to_utf8_buffer()
-	var package_size := buffer.size()
-	package.put_u32(0xDEADBEEF)
-	package.put_u32(buffer.size())
-	package.put_data(buffer)
-	return package_size
+## Reproduces GD-1288: a TCP message rarely arrives in one piece, it is split across several
+## reads. `receive_packages()` does not reassemble those pieces, so a split message corrupts
+## the whole stream: the parser loses track of where the next frame starts, and every message
+## after the split fails to deserialize.
+func test_receive_message_split_across_polls(_timeout := 1000) -> void:
+	monitor_signals(tcp_server, false)
 
+	# connect directly with a raw socket so the test controls exactly how many bytes are sent
+	# on each write, instead of `GdUnitTcpClient` sending the whole message in one go
+	var raw := StreamPeerTCP.new()
+	assert_int(raw.connect_to_host("127.0.0.1", server_port)).is_equal(OK)
+	for n in 200:
+		@warning_ignore("return_value_discarded")
+		raw.poll()
+		if raw.get_status() == StreamPeerTCP.STATUS_CONNECTED:
+			break
+		await await_idle_frame()
 
+	var message := RPCMessage.of("A long Message used to simmulate splitted tcp stream")
 
-# TODO refactor out and provide as public interface to can be reuse on other tests
-class TestGdUnitSignalCollector:
-	var _signalCollector: GdUnitSignalCollector
-	var _emitter: Object
+	# build the real wire bytes `GdUnitTcpNode.rpc_send()` would produce, by encoding the same
+	# packet through a `PacketPeerStream` into an in-memory buffer instead of a socket
+	var encoded := StreamPeerBuffer.new()
+	var encoder := PacketPeerStream.new()
+	encoder.stream_peer = encoded
+	var _put_error := encoder.put_packet(message.serialize().to_utf16_buffer())
+	var frame := encoded.data_array
 
+	# send those bytes 16 at a time, one idle frame apart, so the frame arrives split across
+	# multiple socket reads instead of all at once
+	var frame_size := frame.size()
+	var frame_offset := 0
+	while frame_size > 0:
+		var _e := raw.put_data(frame.slice(frame_offset, frame_offset + mini(16, frame_size)))
+		await await_idle_frame()
+		frame_size -= 16
+		frame_offset += 16
 
-	func _init(emitter: Object) -> void:
-		_emitter = emitter
-		_signalCollector = GdUnitSignalCollector.new()
-		_signalCollector.register_emitter(emitter)
+	# the message should still arrive correctly once fully sent - fails on master because the
+	# split desynced the stream and the message never gets reassembled
+	await assert_signal(tcp_server).is_emitted("rpc_data", message)
+	raw.disconnect_from_host()
 
-
-	func is_emitted(signal_name: String, expected_args: Array) -> bool:
-		return _signalCollector.match(_emitter, signal_name, expected_args)
-
-
-	func _notification(what: int) -> void:
-		if what == NOTIFICATION_PREDELETE:
-			_signalCollector.unregister_emitter(_emitter)
-
-
-func signal_collector(instance: Object) -> TestGdUnitSignalCollector:
-	return TestGdUnitSignalCollector.new(instance)
+@warning_ignore_restore("redundant_await")


### PR DESCRIPTION
## Why
Large test suites running through the editor inspector intermittently log "Can't deserialize JSON" spam, and in the worst case the whole engine can hang, because the hand-rolled TCP framing discards any frame whose payload has not fully arrived by the time it polls, leaving the connection permanently desynced for every later message.

## What
- Replaces the hand-rolled magic-number and length-prefix framing with Godot's built-in packet framing, which buffers partial reads across polls instead of assuming a full message always arrives in one piece
- Fixes a connection leak where a client disconnecting without a graceful handshake left its server-side node unfreed, since the close path only freed the node while the underlying socket was still connected
- Guards a report lookup against an empty report list to avoid an out-of-range access
- Adds an integration test that reproduces the original desync by feeding the server a message split across multiple socket reads
- Refactors the existing integration tests to use the framework's own signal monitoring instead of a hand-rolled signal collector that had accumulated in the test file over time

Closes #1288
