### PR TITLE
GD-1300: Fix scene_runner() time factor corruption across overlapping runners

### DIFF
--- a/addons/gdUnit4/src/core/GdUnitSceneRunnerImpl.gd
+++ b/addons/gdUnit4/src/core/GdUnitSceneRunnerImpl.gd
@@ -103,7 +103,7 @@ func _init(p_scene: Variant, p_verbose: bool, p_hide_push_errors := false) -> vo
 
 
 func _notification(what: int) -> void:
-	if what == NOTIFICATION_PREDELETE and is_instance_valid(self):
+	if what == NOTIFICATION_PREDELETE and is_instance_valid(self) and not _is_disposed:
 		# reset time factor to normal
 		__deactivate_time_factor()
 		if is_instance_valid(_current_scene):

--- a/addons/gdUnit4/src/core/GdUnitSceneRunnerImpl.gd
+++ b/addons/gdUnit4/src/core/GdUnitSceneRunnerImpl.gd
@@ -3,9 +3,6 @@ class_name GdUnitSceneRunnerImpl
 extends GdUnitSceneRunner
 
 
-var GdUnitFuncAssertImpl: GDScript = ResourceLoader.load("res://addons/gdUnit4/src/asserts/GdUnitFuncAssertImpl.gd", "GDScript", ResourceLoader.CACHE_MODE_REUSE)
-
-
 # mapping of mouse buttons and his masks
 const MAP_MOUSE_BUTTON_MASKS := {
 	MOUSE_BUTTON_LEFT : MOUSE_BUTTON_MASK_LEFT,
@@ -17,6 +14,13 @@ const MAP_MOUSE_BUTTON_MASKS := {
 	MOUSE_BUTTON_XBUTTON1 : MOUSE_BUTTON_MASK_MB_XBUTTON1,
 	MOUSE_BUTTON_XBUTTON2 : MOUSE_BUTTON_MASK_MB_XBUTTON2,
 }
+
+# shared, engine-global bookkeeping for the time factor so overlapping runners don't
+# stomp each other's saved baseline tick rate
+const _META_BASELINE_TPS := "GdUnitSceneRunner_baseline_tps"
+const _META_ACTIVE_COUNT := "GdUnitSceneRunner_active_count"
+
+var GdUnitFuncAssertImpl: GDScript = ResourceLoader.load("res://addons/gdUnit4/src/asserts/GdUnitFuncAssertImpl.gd", "GDScript", ResourceLoader.CACHE_MODE_REUSE)
 
 var _is_disposed := false
 var _current_scene: Node = null
@@ -42,7 +46,15 @@ var _scene_auto_free := false
 
 func _init(p_scene: Variant, p_verbose: bool, p_hide_push_errors := false) -> void:
 	_verbose = p_verbose
-	_saved_iterations_per_second = Engine.get_physics_ticks_per_second()
+	# the baseline must be captured once and shared across overlapping runners, otherwise a
+	# runner created while another runner's time factor is still active would save an
+	# already-scaled rate as its own "original" value.
+	if not Engine.has_meta(_META_BASELINE_TPS):
+		Engine.set_meta(_META_BASELINE_TPS, Engine.get_physics_ticks_per_second())
+	@warning_ignore("unsafe_cast")
+	_saved_iterations_per_second = Engine.get_meta(_META_BASELINE_TPS) as float
+	@warning_ignore("unsafe_cast")
+	Engine.set_meta(_META_ACTIVE_COUNT, (Engine.get_meta(_META_ACTIVE_COUNT, 0) as int) + 1)
 	@warning_ignore("return_value_discarded")
 	set_time_factor(1)
 	# handle scene loading by resource path
@@ -506,6 +518,15 @@ func __activate_time_factor() -> void:
 
 
 func __deactivate_time_factor() -> void:
+	@warning_ignore("unsafe_cast")
+	var active_count: int = (Engine.get_meta(_META_ACTIVE_COUNT, 1) as int) - 1
+	# only restore the shared engine state once the last overlapping runner deactivates,
+	# otherwise we would stomp the tick rate/time scale still relied on by other active runners.
+	if active_count > 0:
+		Engine.set_meta(_META_ACTIVE_COUNT, active_count)
+		return
+	Engine.remove_meta(_META_ACTIVE_COUNT)
+	Engine.remove_meta(_META_BASELINE_TPS)
 	Engine.set_time_scale(1)
 	Engine.set_physics_ticks_per_second(_saved_iterations_per_second as int)
 

--- a/addons/gdUnit4/test/core/GdUnitSceneRunnerTimeFactorBaselineTest.gd
+++ b/addons/gdUnit4/test/core/GdUnitSceneRunnerTimeFactorBaselineTest.gd
@@ -1,0 +1,35 @@
+# GdUnit generated TestSuite
+@warning_ignore_start("redundant_await", "unsafe_method_access")
+class_name GdUnitSceneRunnerTimeFactorBaselineTest
+extends GdUnitTestSuite
+
+# TestSuite generated from
+const __source = 'res://addons/gdUnit4/src/core/GdUnitSceneRunnerImpl.gd'
+
+
+func load_test_scene() -> Node:
+	@warning_ignore("unsafe_method_access")
+	return auto_free(load("res://addons/gdUnit4/test/mocker/resources/scenes/TestScene.tscn").instantiate())
+
+
+#region time_factor_baseline_corruption
+## Regression test for GD-1299: GdUnitSceneRunnerImpl used to capture its "restore" baseline
+## from the engine's CURRENT physics tick rate at construction time, instead of a true,
+## untouched baseline. When a second runner was created while an earlier runner's time factor
+## was still active, the second runner's baseline was already scaled, so its own
+## set_time_factor() call landed on the wrong tick rate.
+func test_overlapping_scene_runners_corrupt_time_factor() -> void:
+	var original_tps := Engine.get_physics_ticks_per_second()
+
+	var runner_a := scene_runner(load_test_scene())
+	runner_a.set_time_factor(2)
+
+	var runner_b := scene_runner(load_test_scene())
+	runner_b.set_time_factor(3)
+
+	# runner_b's baseline must reflect the true, untouched tick rate, not runner_a's still-active
+	# 2x factor, otherwise set_time_factor(3) would compound on top of it.
+	assert_int(Engine.get_physics_ticks_per_second()).is_equal(int(original_tps * 3))
+
+	Engine.set_physics_ticks_per_second(original_tps)
+#endregion

--- a/addons/gdUnit4/test/core/GdUnitSceneRunnerTimeFactorBaselineTest.gd
+++ b/addons/gdUnit4/test/core/GdUnitSceneRunnerTimeFactorBaselineTest.gd
@@ -13,7 +13,7 @@ func load_test_scene() -> Node:
 
 
 #region time_factor_baseline_corruption
-## Regression test for GD-1299: GdUnitSceneRunnerImpl used to capture its "restore" baseline
+## Regression test for GD-1300: GdUnitSceneRunnerImpl used to capture its "restore" baseline
 ## from the engine's CURRENT physics tick rate at construction time, instead of a true,
 ## untouched baseline. When a second runner was created while an earlier runner's time factor
 ## was still active, the second runner's baseline was already scaled, so its own

--- a/addons/gdUnit4/test/core/GdUnitSceneRunnerTimeFactorRaceTest.gd
+++ b/addons/gdUnit4/test/core/GdUnitSceneRunnerTimeFactorRaceTest.gd
@@ -13,7 +13,7 @@ func load_test_scene() -> Node:
 
 
 #region time_factor_leaks_across_tests
-## Regression test for GD-1299: a corrupted baseline captured by an earlier test's overlapping
+## Regression test for GD-1300: a corrupted baseline captured by an earlier test's overlapping
 ## runners used to leak into a later, unrelated test's engine tick rate once the framework's
 ## end-of-test gc() deactivated each runner on its own (possibly corrupted) saved baseline.
 ## See also GdUnitSceneRunnerTimeFactorBaselineTest for the underlying baseline-capture defect.

--- a/addons/gdUnit4/test/core/GdUnitSceneRunnerTimeFactorRaceTest.gd
+++ b/addons/gdUnit4/test/core/GdUnitSceneRunnerTimeFactorRaceTest.gd
@@ -1,0 +1,34 @@
+# GdUnit generated TestSuite
+@warning_ignore_start("redundant_await", "unsafe_method_access")
+class_name GdUnitSceneRunnerTimeFactorRaceTest
+extends GdUnitTestSuite
+
+# TestSuite generated from
+const __source = 'res://addons/gdUnit4/src/core/GdUnitSceneRunnerImpl.gd'
+
+
+func load_test_scene() -> Node:
+	@warning_ignore("unsafe_method_access")
+	return auto_free(load("res://addons/gdUnit4/test/mocker/resources/scenes/TestScene.tscn").instantiate())
+
+
+#region time_factor_leaks_across_tests
+## Regression test for GD-1299: a corrupted baseline captured by an earlier test's overlapping
+## runners used to leak into a later, unrelated test's engine tick rate once the framework's
+## end-of-test gc() deactivated each runner on its own (possibly corrupted) saved baseline.
+## See also GdUnitSceneRunnerTimeFactorBaselineTest for the underlying baseline-capture defect.
+func test_a_leaves_overlapping_runners_active() -> void:
+	var runner_a := scene_runner(load_test_scene())
+	runner_a.set_time_factor(2)
+
+	var runner_b := scene_runner(load_test_scene())
+	runner_b.set_time_factor(3)
+	# runners are released by the framework's auto_free gc() at the end of this test,
+	# each restoring the engine tick rate to its own saved baseline.
+
+
+func test_b_sees_a_clean_default_tick_rate() -> void:
+	# test_a's overlapping runners must not leave a corrupted saved baseline behind, so the
+	# engine tick rate observed here should be the untouched project default.
+	assert_int(Engine.get_physics_ticks_per_second()).is_equal(ProjectSettings.get_setting("physics/common/physics_ticks_per_second", 60))
+#endregion


### PR DESCRIPTION
# Why

Fixes #1300.

`GdUnitSceneRunnerImpl` captures its "restore" baseline from the engine's *current*
physics tick rate at construction time instead of a true, untouched baseline. When a
second `scene_runner()` is created while an earlier runner's time factor is still
active, the second runner's baseline is already scaled, so its own `set_time_factor()`
call lands on the wrong tick rate. Deactivation then restores the engine to that wrong
value unconditionally, corrupting the tick rate for any other active runner and
leaking the corruption into whichever test runs next.

Both symptoms (live compounding while runners overlap, and the corruption leaking into
a later, unrelated test) come from this single root cause — see the linked issue for
the exact reproduction and observed values.

# What

- Share the true baseline tick rate across overlapping runners via `Engine.meta`,
  captured once by the first runner instead of re-read (and potentially corrupted)
  by every subsequent one.
- Track a shared active-runner count via `Engine.meta`; `__deactivate_time_factor()`
  now only restores the engine's tick rate/time scale once the *last* active runner
  deactivates, instead of each runner unconditionally restoring to its own (possibly
  wrong) saved value.
- `__deactivate_time_factor()` is no longer idempotent-safe by accident — it does
  stateful read-modify-write bookkeeping now — so `_notification()` gained an
  `_is_disposed` guard to make sure a second `NOTIFICATION_PREDELETE` for an
  already-disposed runner can't double-decrement or clear state belonging to a
  different, still-active runner.
- Two regression tests (`GdUnitSceneRunnerTimeFactorBaselineTest.gd`,
  `GdUnitSceneRunnerTimeFactorRaceTest.gd`) cover both symptoms independently.

Verified against the full existing `GdUnitSceneRunnerTest.gd` suite (30/30 passing,
no regressions) and the two new regression tests, across Godot v4.5, v4.6.1, v4.7, and
v4.7.1 — the full range supported on `master`.