### PR TITLE
GD-1302: Support single quotes on callable expressions for `test_parameters `

### DIFF
--- a/addons/gdUnit4/src/core/parameters/GdCallableParameterSetResolver.gd
+++ b/addons/gdUnit4/src/core/parameters/GdCallableParameterSetResolver.gd
@@ -6,6 +6,7 @@ var _expression: String
 var _parameters: Array[Array]
 
 var _func_call_regex := RegEx.create_from_string("^(\\w+)\\((.*)\\)$")
+var _string_regex := RegEx.create_from_string("^(['\"])(.*?)\\1$")
 
 
 func _init(instance: Node, expression: String, args: Array[GdFunctionArgument] = []) -> void:
@@ -52,8 +53,58 @@ func _compile(instance: Node, expression: String) -> Array[Array]:
 
 func _parse_arguments(args_str: String) -> Array:
 	var result: Array = []
-	for raw: String in args_str.split(","):
+
+	args_str = args_str.strip_edges()
+	if args_str.is_empty():
+		return result
+
+	for raw: String in _split_argumens(args_str):
 		var value := raw.strip_edges()
-		var converted: Variant = str_to_var(value)
-		result.append(converted if converted != null else value)
+		var quoted_string_value := _string_regex.search(value)
+		if quoted_string_value != null:
+			result.append(quoted_string_value.get_string(2))
+			continue
+		result.append(str_to_var(value))
+	return result
+
+
+static func _split_argumens(input: String) -> Array[String]:
+	var result: Array[String] = []
+	var current := ""
+	var in_quote := false
+	var quote_char := ""
+	var i := 0
+
+	while i < input.length():
+		var character := input[i]
+
+		if character == "\\":
+			if i + 1 < input.length():
+				current += input[i + 1]
+				i += 2
+				continue
+
+		if character == '"' or character == "'":
+			if not in_quote:
+				in_quote = true
+				quote_char = character
+			elif character == quote_char:
+				in_quote = false
+				quote_char = ""
+
+			current += character
+			i += 1
+			continue
+
+		if character == "," and not in_quote:
+			result.append(current.strip_edges())
+			current = ""
+			i += 1
+			continue
+
+		current += character
+		i += 1
+
+	if current != "":
+		result.append(current.strip_edges())
 	return result

--- a/addons/gdUnit4/test/core/parameters/GdCallableParameterSetResolverTest.gd
+++ b/addons/gdUnit4/test/core/parameters/GdCallableParameterSetResolverTest.gd
@@ -53,6 +53,14 @@ func _parameters_with_references_typed() -> Array[Array]:
 	]
 
 
+func _parameters_string_arg(arg1: String, arg2: String) -> Array[Array]:
+	return [[arg1, arg2]]
+
+
+func _parameters_string_args(arg1: String, arg2: String) ->  Array[Array]:
+	return [[arg1, arg2]]
+
+
 func before() -> void:
 	_obj = auto_free(Node2D.new())
 
@@ -172,6 +180,83 @@ func test_get_parameters_dynamic_referenced() -> void:
 
 	# We used the function `_parameters_with_references_typed()` that builds a parameter set with size 9
 	assert_int(resolver.get_max_index()).is_equal(9)
+
+
+func test_get_parameters_string_values() -> void:
+	# Using double qoutas
+	var resolver := GdCallableParameterSetResolver.new(self, """_parameters_string_arg("abc", "def")""")
+
+	var parameters := resolver.get_parameters(self, 0)
+	assert_array(parameters).has_size(3)
+	assert_str(parameters[0]).is_equal("abc")
+	assert_str(parameters[1]).is_equal("def")
+	assert_object(parameters[2]).is_equal([])
+
+	# Using single qoutas see https://github.com/godot-gdunit-labs/gdUnit4/issues/1302
+	resolver = GdCallableParameterSetResolver.new(self, """_parameters_string_arg('abc', 'd'ef')""")
+
+	parameters = resolver.get_parameters(self, 0)
+	assert_array(parameters).has_size(3)
+	assert_str(parameters[0]).is_equal("abc")
+	assert_str(parameters[1]).is_equal("d'ef")
+	assert_object(parameters[2]).is_equal([])
+
+
+func test_get_parameters_string_values_with_comma() -> void:
+	# Using comma in strings
+	var resolver := GdCallableParameterSetResolver.new(self, """_parameters_string_arg("abc", "d,ef")""")
+
+	var parameters := resolver.get_parameters(self, 0)
+	assert_array(parameters).has_size(3)
+	assert_str(parameters[0]).is_equal("abc")
+	assert_str(parameters[1]).is_equal("d,ef")
+	assert_object(parameters[2]).is_equal([])
+
+
+func test_split_argumens1(arg1: String, arg2: String, _test_parameters := _parameters_string_arg("abc", "d,ef")) -> void:
+	assert_str(arg1).is_equal("abc")
+	assert_str(arg2).is_equal("d,ef")
+
+
+func test_split_argumens2(arg1: String, arg2: String, _test_parameters := _parameters_string_arg('abc', 'd"ef')) -> void:
+	assert_str(arg1).is_equal("abc")
+	assert_str(arg2).is_equal("d\"ef")
+
+
+# TODO, the parsing '"d\"ef"' let Godot crash here
+func _test_split_argumens3(arg1: String, arg2: String, _test_parameters := _parameters_string_arg('abc', "d\"ef")) -> void:
+	assert_str(arg1).is_equal("abc")
+	assert_str(arg2).is_equal("d\"ef")
+
+
+func test_split_argumens() -> void:
+	assert_array(GdCallableParameterSetResolver._split_argumens('"abc", "d,ef"'))\
+		.contains_exactly([
+			'"abc"',
+			'"d,ef"'
+		])
+	assert_array(GdCallableParameterSetResolver._split_argumens('"abc", "d\"ef"'))\
+		.contains_exactly([
+			'"abc"',
+			'"d\"ef"'
+		])
+	assert_array(GdCallableParameterSetResolver._split_argumens("'abc', 'd,ef'"))\
+		.contains_exactly([
+			"'abc'",
+			"'d,ef'"
+		])
+	assert_array(GdCallableParameterSetResolver._split_argumens("'abc', 'd\"ef'"))\
+		.contains_exactly([
+			"'abc'",
+			"'d\"ef'"
+		])
+	assert_array(GdCallableParameterSetResolver._split_argumens('12, Node3d.new(), true, "d,ef"'))\
+		.contains_exactly([
+			"12",
+			'Node3d.new()',
+			"true",
+			'"d,ef"'
+		])
 
 #region performance
 

--- a/addons/gdUnit4/test/core/parameters/GdInlineParameterSetResolverTest.gd
+++ b/addons/gdUnit4/test/core/parameters/GdInlineParameterSetResolverTest.gd
@@ -18,6 +18,9 @@ var example_parameters := [
 	'_test_set_a]'
 	]
 
+func parameters_as_array(arg1: String, arg2: String) -> Array[String]:
+	return [arg1, arg2]
+
 class TestObj:
 
 	func _init() -> void:
@@ -480,6 +483,14 @@ func test_resolve_parameters_with_scrip_constans() -> void:
 			["array", TYPE_ARRAY, []],
 			["packed_array", TYPE_PACKED_BYTE_ARRAY, []]
 			])
+
+
+# TODO the parameter resolver has issues with using callables inside inline parameter sets
+func _test_resolve_parameters_with_array_functions(arg1: String, arg2: String, _test_parameters := [
+	parameters_as_array("abc", "d,ef")
+	]) -> void:
+	assert_str(arg1).is_equal("abc")
+	assert_str(arg2).is_equal("d,ef")
 
 
 func _resolve_parameters(child_name: String) -> Array[Array]:

--- a/addons/gdUnit4/test/core/parameters/GdParameterSetResolverFactoryTest.gd
+++ b/addons/gdUnit4/test/core/parameters/GdParameterSetResolverFactoryTest.gd
@@ -15,6 +15,9 @@ func _callable_parameters(_a: int, _b: int, _test_parameters := _build_params())
 	pass
 
 
+func _callable_parameters_with_args(_a: int, _b: int, _test_parameters := _parameters_string_args("abc", "def")) -> void:
+	pass
+
 func _properties_parameters(_a: int, _b: int, _test_parameters := _test_properties) -> void:
 	pass
 
@@ -25,6 +28,10 @@ func _no_parameters(_a: int, _b: int) -> void:
 
 func _build_params() -> Array[Array]:
 	return [[1, 2], [3, 4]]
+
+
+func _parameters_string_args(arg1: String, arg2: String) ->  Array[Array]:
+	return [[arg1, arg2]]
 
 
 func _descriptor(func_name: String) -> GdFunctionDescriptor:
@@ -49,6 +56,12 @@ func test_create_returns_callable_resolver() -> void:
 	var resolver := GdParameterSetResolverFactory.create(_descriptor("_callable_parameters"), self)
 	assert_object(resolver).is_instanceof(GdCallableParameterSetResolver)
 	assert_int(resolver.get_max_index()).is_equal(2)
+
+
+func test_create_returns_callable_resolver_with_args() -> void:
+	var resolver := GdParameterSetResolverFactory.create(_descriptor("_callable_parameters_with_args"), self)
+	assert_object(resolver).is_instanceof(GdCallableParameterSetResolver)
+	assert_int(resolver.get_max_index()).is_equal(1)
 
 
 func test_create_returns_property_resolver() -> void:


### PR DESCRIPTION
# Why

Using single quotes within a callable for test parameters converts it into a string value that includes the single quotes. ` test_parameters := get_test_params('foo', 'bar')`

# What

Fixed `GdCallableParameterSetResolver` to split arguments passed as strings into a list of strings, taking into account single quotes and string values that contain commas.

Two additional bugs were found:
-  using quotes inside a string value let the parser crash
```
func _test_split_argumens3(arg1: String, arg2: String, _test_parameters := _parameters_string_arg('abc', "d\"ef")) -> void:
```
- the inline paramters resolver has issues using callables
```
func parameters_as_array(arg1: String, arg2: String) -> Array[String]:
	return [arg1, arg2]

 func _test_resolve_parameters_with_array_functions(arg1: String, arg2: String, _test_parameters := [
	parameters_as_array("abc", "d,ef")
	]) -> void:
	assert_str(arg1).is_equal("abc")
	assert_str(arg2).is_equal("d,ef")
  ```
