### PR TITLE
Reopen issues issue-triage closed before type was set

### DIFF
--- a/.github/actions/resolve-issue-template/action.yml
+++ b/.github/actions/resolve-issue-template/action.yml
@@ -23,6 +23,9 @@ outputs:
   required-ids:
     description: JSON array of the matched template's required field ids.
     value: ${{ steps.resolve.outputs.required-ids }}
+  labels:
+    description: Comma separated list of the issue's current label names.
+    value: ${{ steps.resolve.outputs.labels }}
 
 runs:
   using: composite

--- a/.github/actions/resolve-issue-template/resolve.sh
+++ b/.github/actions/resolve-issue-template/resolve.sh
@@ -6,6 +6,7 @@ gh api "repos/$GITHUB_REPOSITORY/issues/$ISSUE_NUMBER" > triage/issue.json
 
 echo "number=$(jq -r '.number' triage/issue.json)" >> "$GITHUB_OUTPUT"
 echo "state=$(jq -r '.state // "open"' triage/issue.json)" >> "$GITHUB_OUTPUT"
+echo "labels=$(jq -r '[.labels[].name] | join(",")' triage/issue.json)" >> "$GITHUB_OUTPUT"
 
 type_name=$(jq -r '.type.name // empty' triage/issue.json | tr '[:upper:]' '[:lower:]')
 

--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -46,9 +46,10 @@ jobs:
     outputs:
       bypass: ${{ steps.verdict.outputs.bypass }}
       number: ${{ steps.resolve.outputs.number }}
-      state: ${{ steps.resolve.outputs.state }}
+      state: ${{ steps.reopen.outputs.state || steps.resolve.outputs.state }}
       template-name: ${{ steps.resolve.outputs.template-name }}
       required-ids: ${{ steps.resolve.outputs.required-ids }}
+      labels: ${{ steps.resolve.outputs.labels }}
 
     steps:
       - name: Checkout GdUnit Repository
@@ -144,6 +145,74 @@ jobs:
           if [ "$close" = 'true' ]; then
             gh issue close "$NUMBER" --repo "$GITHUB_REPOSITORY" --reason 'not planned'
           fi
+
+      # Native issue type can only be set via a GraphQL call made after the issue already exists,
+      # so the `opened` webhook always sees an untyped issue and the step above closes it even when
+      # the issue was filed correctly through a template. A later `edited` run (e.g. the creating
+      # tool's title-rename, done once the type is set) resolves the template correctly here, but
+      # that only skips the reject step above — it does not undo the earlier wrongful close. This
+      # step detects that case and reopens the issue instead.
+      - name: Reopen Previously Bypassed Issue
+        id: reopen
+        if: steps.verdict.outputs.bypass == 'false' && steps.resolve.outputs.state == 'closed' && !contains(steps.resolve.outputs.labels, env.PASSED_LABEL) && !contains(steps.resolve.outputs.labels, env.UNVERIFIABLE_LABEL)
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          NUMBER: ${{ steps.resolve.outputs.number }}
+          EVENT_NAME: ${{ github.event_name }}
+          INPUT_DRY_RUN: ${{ inputs.dry_run }}
+        run: |
+          set -euo pipefail
+          DRY_RUN='false'
+          if [ "$EVENT_NAME" = 'workflow_dispatch' ]; then
+            DRY_RUN="$INPUT_DRY_RUN"
+          fi
+
+          {
+            echo "$MARKER"
+            echo
+            echo '## This issue was reopened by automated triage'
+            echo
+            echo 'This issue was closed earlier for appearing to skip the issue templates, but a'
+            echo 'later edit now resolves it to a recognized template type. The earlier closure no'
+            echo 'longer applies, so the issue has been reopened.'
+          } > triage/comment.md
+
+          {
+            echo "## Issue triage for #$NUMBER"
+            echo
+            if [ "$DRY_RUN" = 'true' ]; then
+              echo 'Mode: **DRY RUN, nothing was written**'
+            else
+              echo 'Mode: **applied**'
+            fi
+            echo
+            echo 'Decision: a previously bypass-rejected issue now resolves to a recognized template type'
+            echo
+            echo '- issue reopened: true'
+            echo
+            echo '<details><summary>Triage comment</summary>'
+            echo
+            cat triage/comment.md
+            echo
+            echo '</details>'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          if [ "$DRY_RUN" = 'true' ]; then
+            exit 0
+          fi
+
+          comment_id=$(gh api --paginate "repos/$GITHUB_REPOSITORY/issues/$NUMBER/comments" \
+            --jq "[.[] | select(.body | contains(\"$MARKER\")) | .id] | first // empty")
+          jq -n --rawfile body triage/comment.md '{body: $body}' > triage/comment.json
+          if [ -z "$comment_id" ]; then
+            gh api --method POST "repos/$GITHUB_REPOSITORY/issues/$NUMBER/comments" --input triage/comment.json
+          else
+            gh api --method PATCH "repos/$GITHUB_REPOSITORY/issues/comments/$comment_id" --input triage/comment.json
+          fi
+
+          gh issue reopen "$NUMBER" --repo "$GITHUB_REPOSITORY"
+          echo "state=open" >> "$GITHUB_OUTPUT"
 
   llm-review:
     name: LLM Review


### PR DESCRIPTION
## Why
`issue-triage.yml`'s bypass-rejection step reads the issue's native `type`, but `type` can only be set via a GraphQL call made after the issue exists, so the `opened` webhook always sees an untyped issue and closes it even when it was filed correctly through a template; a later `edited` run resolving the type correctly only skipped re-closing, it never undid the earlier wrongful close (confirmed live: godot-gdunit-labs/ai-harness-core#2, reproduced end-to-end in this repo with a real test issue after the `create-issue` skill fix landed).

## What
Added a "Reopen Previously Bypassed Issue" step that reopens the issue (and updates the sticky triage comment) when a later run resolves the type to a recognized template and the earlier close carries no `triage:passed`/`triage:failed` label, plus threaded the corrected state through to the LLM review job so it doesn't act on the stale pre-reopen state.

Closes godot-gdunit-labs/ai-harness-core#2