### PR TITLE
GD-1312: Fix spy build crash on classes defining `static func _static_init()`

### DIFF
--- a/addons/gdUnit4/src/core/parse/GdFunctionDescriptor.gd
+++ b/addons/gdUnit4/src/core/parse/GdFunctionDescriptor.gd
@@ -152,7 +152,7 @@ func _to_string() -> String:
 
 
 # extract function description given by Object.get_method_list()
-static func extract_from(descriptor :Dictionary, is_engine_ := true) -> GdFunctionDescriptor:
+static func extract_from(descriptor: Dictionary, is_engine_ := true) -> GdFunctionDescriptor:
 	var func_name: String = descriptor["name"]
 	var function_flags: int = descriptor["flags"]
 	var return_descriptor: Dictionary = descriptor["return"]
@@ -162,6 +162,11 @@ static func extract_from(descriptor :Dictionary, is_engine_ := true) -> GdFuncti
 	var is_vararg_: bool = function_flags & METHOD_FLAG_VARARG
 
 	var return_type_ := _extract_return_type(return_descriptor)
+
+	# Add hotfix to handle Godot bug https://github.com/godotengine/godot/issues/122629
+	if func_name == '_static_init':
+		return_type_ = GdObjects.TYPE_VOID
+
 	return GdFunctionDescriptor.new(
 		func_name,
 		is_virtual_,
@@ -198,8 +203,8 @@ const enum_fix := [
 
 
 static func _extract_return_type(return_info: Dictionary) -> int:
-	var type :int = return_info["type"]
-	var usage :int = return_info["usage"]
+	var type: int = return_info["type"]
+	var usage: int = return_info["usage"]
 	if usage & PROPERTY_USAGE_CLASS_IS_ENUM:
 		return GdObjects.TYPE_ENUM
 	if usage & PROPERTY_USAGE_NIL_IS_VARIANT:

--- a/addons/gdUnit4/test/core/parse/GdScriptParsingFunctionDescriptorsTest.gd
+++ b/addons/gdUnit4/test/core/parse/GdScriptParsingFunctionDescriptorsTest.gd
@@ -470,7 +470,25 @@ func test_parse_fuzz_do_skip_param_GD_1157() -> void:
 		)
 
 
+func test_static_functions() -> void:
+	var script: GDScript = load("res://addons/gdUnit4/test/core/resources/parsing/functions/ClassWithStaticFunctions.gd")
+
+	var fds := _parser.get_function_descriptors(script, [])
+	assert_that(fds[0])\
+		.is_equal(create_static("_static_init", script.resource_path, 4, 5, GdObjects.TYPE_VOID, [])
+		)
+	assert_that(fds[1])\
+		.is_equal(create_static("_static_init2", script.resource_path, 8, 9, GdObjects.TYPE_VOID, [])
+		)
+
+
 static func create(func_name: String, source_path: String, begin_line: int, end_line: int, return_type: int, args: Array[GdFunctionArgument] = []) -> GdFunctionDescriptor:
 	var fd := GdFunctionDescriptor.new(func_name, false, false, false, return_type, "", args)
+	fd.enrich_file_info(source_path, begin_line, end_line)
+	return fd
+
+
+static func create_static(func_name: String, source_path: String, begin_line: int, end_line: int, return_type: int, args: Array[GdFunctionArgument] = []) -> GdFunctionDescriptor:
+	var fd := GdFunctionDescriptor.new(func_name, false, true, false, return_type, "", args)
 	fd.enrich_file_info(source_path, begin_line, end_line)
 	return fd

--- a/addons/gdUnit4/test/core/resources/parsing/functions/ClassWithStaticFunctions.gd
+++ b/addons/gdUnit4/test/core/resources/parsing/functions/ClassWithStaticFunctions.gd
@@ -1,0 +1,9 @@
+extends RefCounted
+
+
+static func _static_init() -> void:
+	pass
+
+
+static func _static_init2() -> void:
+	pass

--- a/addons/gdUnit4/test/spy/GdUnitSpyTest.gd
+++ b/addons/gdUnit4/test/spy/GdUnitSpyTest.gd
@@ -436,6 +436,9 @@ func test_verify_no_more_interactions_but_has() -> void:
 
 class ClassWithStaticFunctions:
 
+	static func _static_init() -> void:
+		return
+
 	static func foo() -> void:
 		pass
 


### PR DESCRIPTION
## Why

Spying a class that defines `static func _static_init()` failed with `Parse Error: Constructor cannot return a value.` The root cause is a Godot reflection bug (godotengine/godot#122629) that misreports `_static_init`'s return type as non-void, so gdUnit4's generated spy override included a `return` statement inside a function GDScript treats as a constructor, which Godot rejects.

## What

- `GdFunctionDescriptor.extract_from` now forces the return type to void for `_static_init`, so the doubler generates a bare `return` matching what Godot expects
- Added `test_static_functions` covering descriptor extraction for `_static_init`
- Extended `GdUnitSpyTest.gd` to spy a class defining `_static_init()`

Closes #1312