### PR TITLE
GD-1310: Fix inline parameter resolver failing on array literals with callable calls

### DIFF
--- a/addons/gdUnit4/src/core/parameters/GdParameterSetResolver.gd
+++ b/addons/gdUnit4/src/core/parameters/GdParameterSetResolver.gd
@@ -107,8 +107,9 @@ func validate(parameters: Array, index: int) -> GdUnitResult:
 ## Duplicates [param parameters] first when it is read-only (e.g. a GDScript class constant).
 ## Also coerces untyped [Array] values to typed arrays
 func _finalize_parameter_set(parameters: Array) -> Array:
-	if parameters.is_read_only():
-		parameters = parameters.duplicate()
+	# need an untyped copy, else appending EMPTY_SET below fails on a typed Array.
+	if parameters.is_read_only() or parameters.is_typed():
+		parameters = Array(parameters, TYPE_NIL, "", null)
 
 	# Convert to typed Array and Dictionary parameters if required
 	for spec: ParameterSpec in _parameter_specs:

--- a/addons/gdUnit4/src/core/parse/GdFunctionArgument.gd
+++ b/addons/gdUnit4/src/core/parse/GdFunctionArgument.gd
@@ -154,6 +154,7 @@ static func _parse_parameters(input: String) -> PackedStringArray:
 	work.resize(buf.size())
 	var wp := 0
 	var array_depth := 0
+	var func_call_depth := 0
 	var after_comma := false
 
 	for c: int in buf:
@@ -163,7 +164,7 @@ static func _parse_parameters(input: String) -> PackedStringArray:
 		if c == 32:
 			if in_string:
 				work[wp] = c; wp += 1; after_comma = false
-			elif array_depth > 0 and not after_comma:
+			elif (array_depth > 0 or func_call_depth > 0) and not after_comma:
 				work[wp] = c; wp += 1
 
 		# '\n': strip newlines outside quoted strings, preserve inside
@@ -173,7 +174,7 @@ static func _parse_parameters(input: String) -> PackedStringArray:
 
 		# ',': step over array element seperator ','
 		elif c == 44:
-			if array_depth == 0:
+			if array_depth == 0 and func_call_depth == 0:
 				if wp > 0:
 					@warning_ignore("return_value_discarded")
 					output.append(work.slice(0, wp).get_string_from_utf8())
@@ -211,6 +212,21 @@ static func _parse_parameters(input: String) -> PackedStringArray:
 		elif c == 93:
 			if not in_string:
 				array_depth -= 1
+			after_comma = false
+			work[wp] = c; wp += 1
+
+		# '('
+		elif c == 40:
+			if not in_string:
+				func_call_depth += 1
+			if after_comma:
+				work[wp] = 32; wp += 1; after_comma = false
+			work[wp] = c; wp += 1
+
+		# ')'
+		elif c == 41:
+			if not in_string:
+				func_call_depth -= 1
 			after_comma = false
 			work[wp] = c; wp += 1
 		else:

--- a/addons/gdUnit4/test/core/parameters/GdInlineParameterSetResolverTest.gd
+++ b/addons/gdUnit4/test/core/parameters/GdInlineParameterSetResolverTest.gd
@@ -18,8 +18,8 @@ var example_parameters := [
 	'_test_set_a]'
 	]
 
-func parameters_as_array(arg1: String, arg2: String) -> Array[String]:
-	return [arg1, arg2]
+func parameters_as_array(index: int, arg1: String, arg2: String) -> Array[Variant]:
+	return [index, arg1, arg2]
 
 class TestObj:
 
@@ -485,12 +485,16 @@ func test_resolve_parameters_with_scrip_constans() -> void:
 			])
 
 
-# TODO the parameter resolver has issues with using callables inside inline parameter sets
-func _test_resolve_parameters_with_array_functions(arg1: String, arg2: String, _test_parameters := [
-	parameters_as_array("abc", "d,ef")
+func test_resolve_parameters_with_array_functions(index: int, arg1: String, arg2: String, _test_parameters := [
+	parameters_as_array(0, "abc", "d,ef"),
+	parameters_as_array(1, "xxx", "foo(y)"),
 	]) -> void:
-	assert_str(arg1).is_equal("abc")
-	assert_str(arg2).is_equal("d,ef")
+	if index == 0:
+		assert_str(arg1).is_equal("abc")
+		assert_str(arg2).is_equal("d,ef")
+	elif index == 1:
+		assert_str(arg1).is_equal("xxx")
+		assert_str(arg2).is_equal("foo(y)")
 
 
 func _resolve_parameters(child_name: String) -> Array[Array]:

--- a/addons/gdUnit4/test/core/parse/GdFunctionArgumentTest.gd
+++ b/addons/gdUnit4/test/core/parse/GdFunctionArgumentTest.gd
@@ -172,6 +172,27 @@ func test_parse_parameter_with_strings_contaning_newlines() -> void:
 			"""[9, "\nflowchart TD\nid{"This is a rhombus node"}\n"]""")
 
 
+func test_parse_parameter_array_literal_with_callable_call() -> void:
+	var test_parameters := """[
+			parameters_as_array("abc", "d,ef", "foo()")
+			]"""
+	var fa := GdFunctionArgument.new("test_parameters", TYPE_STRING, test_parameters)
+	assert_array(fa.parameter_sets()).contains_exactly([
+		"""parameters_as_array("abc", "d,ef", "foo()")"""
+		]
+	)
+
+
+func test_parse_parameter_array_literal_with_multiple_callable_calls() -> void:
+	var test_parameters := """[parameters_as_array("abc", "d,ef"), parameters_as_array("x", "y,z")]"""
+	var fa := GdFunctionArgument.new("test_parameters", TYPE_STRING, test_parameters)
+	assert_array(fa.parameter_sets()).contains_exactly([
+		"""parameters_as_array("abc", "d,ef")""",
+		"""parameters_as_array("x", "y,z")"""
+		]
+	)
+
+
 func test_parse_parameter_set() -> void:
 	var result := GdFunctionArgument._parse_parameters(PARAMETER_SET_EXAMPLE)
 	assert_array(result).contains_exactly([


### PR DESCRIPTION
## Why

`_test_parameters` array literals that wrap a callable call, e.g. `[parameters_as_array("abc", "d,ef")]`, resolved to wrong argument values or failed to resolve at all, because the parameter-set parser split on every top-level comma without accounting for commas inside the callable's own argument list.

## What

- Fixed the parameter-set parser to no longer split on commas inside a callable's argument list.
- Fixed a related crash where a typed array returned by the callable caused the parameter count to desync.
- Added and enabled tests covering both fixes.

Closes #1310