### PR TITLE
GD-1309: Fixing parser crash on escaped quotes in `test_parameters`

### DIFF
--- a/addons/gdUnit4/src/core/parse/GdFunctionArgument.gd
+++ b/addons/gdUnit4/src/core/parse/GdFunctionArgument.gd
@@ -156,9 +156,23 @@ static func _parse_parameters(input: String) -> PackedStringArray:
 	var array_depth := 0
 	var func_call_depth := 0
 	var after_comma := false
+	var escape_next := false
 
 	for c: int in buf:
 		var in_string: bool = single_quote or double_quote
+
+		# escaped character inside a string, e.g. `\"` or `\'`: copy through as-is and
+		# do not let it toggle the quote state
+		if escape_next:
+			work[wp] = c; wp += 1
+			escape_next = false
+			continue
+
+		# '\': mark the next character as escaped, only meaningful inside a quoted string
+		if c == 92 and in_string:
+			work[wp] = c; wp += 1
+			escape_next = true
+			continue
 
 		# ' ': ignore spaces between array elements
 		if c == 32:
@@ -185,9 +199,10 @@ static func _parse_parameters(input: String) -> PackedStringArray:
 				if not in_string:
 					after_comma = true
 
-		# '`':
+		# '\'':
 		elif c == 39:
-			single_quote = not single_quote
+			if not double_quote:
+				single_quote = not single_quote
 			if after_comma:
 				work[wp] = 32; wp += 1; after_comma = false
 			work[wp] = c; wp += 1

--- a/addons/gdUnit4/src/core/parse/GdScriptParser.gd
+++ b/addons/gdUnit4/src/core/parse/GdScriptParser.gd
@@ -540,6 +540,22 @@ func _parse_function_arguments(input: String) -> Array[Dictionary]:
 	return arguments
 
 
+## Finds the index of the next [param quote_char] in [param input] starting at [param start],
+## skipping backslash-escaped characters (e.g. [code]\"[/code]) so escaped quotes do not end the string.
+## Returns -1 when no unescaped quote is found.
+func _find_unescaped_quote(input: String, quote_char: String, start: int) -> int:
+	var index := start
+	while index < input.length():
+		var character := input[index]
+		if character == "\\":
+			index += 2
+			continue
+		if character == quote_char:
+			return index
+		index += 1
+	return -1
+
+
 func _parse_end_function(input: String, remove_trailing_char := false) -> String:
 	# find end of function
 	var current_index := 0
@@ -552,7 +568,7 @@ func _parse_end_function(input: String, remove_trailing_char := false) -> String
 		var character := input[current_index]
 		# step over strings
 		if character == "'" :
-			current_index = input.find("'", current_index+1) + 1
+			current_index = _find_unescaped_quote(input, "'", current_index+1) + 1
 			if current_index == 0:
 				push_error("Parsing error on '%s', can't evaluate end of string." % input)
 				return ""
@@ -562,7 +578,7 @@ func _parse_end_function(input: String, remove_trailing_char := false) -> String
 			if input.find('"""', current_index) == current_index:
 				current_index = input.find('"""', current_index+3) + 3
 			else:
-				current_index = input.find('"', current_index+1) + 1
+				current_index = _find_unescaped_quote(input, '"', current_index+1) + 1
 			if current_index == 0:
 				push_error("Parsing error on '%s', can't evaluate end of string." % input)
 				return ""

--- a/addons/gdUnit4/test/core/parameters/GdCallableParameterSetResolverTest.gd
+++ b/addons/gdUnit4/test/core/parameters/GdCallableParameterSetResolverTest.gd
@@ -223,10 +223,14 @@ func test_split_argumens2(arg1: String, arg2: String, _test_parameters := _param
 	assert_str(arg2).is_equal("d\"ef")
 
 
-# TODO, the parsing '"d\"ef"' let Godot crash here
-func _test_split_argumens3(arg1: String, arg2: String, _test_parameters := _parameters_string_arg('abc', "d\"ef")) -> void:
+func test_split_argumens3(arg1: String, arg2: String, _test_parameters := _parameters_string_arg('abc', "d\"ef")) -> void:
 	assert_str(arg1).is_equal("abc")
 	assert_str(arg2).is_equal("d\"ef")
+
+
+func test_split_argumens4(arg1: String, arg2: String, _test_parameters := _parameters_string_arg('abc', 'd\'ef')) -> void:
+	assert_str(arg1).is_equal("abc")
+	assert_str(arg2).is_equal("d'ef")
 
 
 func test_split_argumens() -> void:

--- a/addons/gdUnit4/test/core/parameters/GdInlineParameterSetResolverTest.gd
+++ b/addons/gdUnit4/test/core/parameters/GdInlineParameterSetResolverTest.gd
@@ -486,8 +486,10 @@ func test_resolve_parameters_with_scrip_constans() -> void:
 
 
 func test_resolve_parameters_with_array_functions(index: int, arg1: String, arg2: String, _test_parameters := [
-	parameters_as_array(0, "abc", "d,ef"),
-	parameters_as_array(1, "xxx", "foo(y)"),
+	[0, "abc", "d,ef"],
+	[1, "xxx", "foo(y)"],
+	[2, 'y"yy', "d\"ef"],
+	[3, "z'zz", 'd\'ef'],
 	]) -> void:
 	if index == 0:
 		assert_str(arg1).is_equal("abc")
@@ -495,6 +497,12 @@ func test_resolve_parameters_with_array_functions(index: int, arg1: String, arg2
 	elif index == 1:
 		assert_str(arg1).is_equal("xxx")
 		assert_str(arg2).is_equal("foo(y)")
+	elif index == 2:
+		assert_str(arg1).is_equal('y"yy')
+		assert_str(arg2).is_equal("d\"ef")
+	elif index == 3:
+		assert_str(arg1).is_equal("z'zz")
+		assert_str(arg2).is_equal('d\'ef')
 
 
 func _resolve_parameters(child_name: String) -> Array[Array]:

--- a/addons/gdUnit4/test/core/parse/GdFunctionArgumentTest.gd
+++ b/addons/gdUnit4/test/core/parse/GdFunctionArgumentTest.gd
@@ -193,6 +193,19 @@ func test_parse_parameter_array_literal_with_multiple_callable_calls() -> void:
 	)
 
 
+# https://github.com/godot-gdunit-labs/gdUnit4/issues/1309
+# a literal quote of the *other* quote type, mixed with an escaped quote of the *same*
+# quote type, must not corrupt the quote/bracket tracking and merge separate call elements
+func test_parse_parameter_array_literal_with_escaped_quotes() -> void:
+	var test_parameters := """[parameters_as_array(2, 'y"yy', "d\\"ef"), parameters_as_array(3, "z'zz", 'd\\'ef')]"""
+	var fa := GdFunctionArgument.new("test_parameters", TYPE_STRING, test_parameters)
+	assert_array(fa.parameter_sets()).contains_exactly([
+		"""parameters_as_array(2, 'y"yy', "d\\"ef")""",
+		"""parameters_as_array(3, "z'zz", 'd\\'ef')"""
+		]
+	)
+
+
 func test_parse_parameter_set() -> void:
 	var result := GdFunctionArgument._parse_parameters(PARAMETER_SET_EXAMPLE)
 	assert_array(result).contains_exactly([

--- a/addons/gdUnit4/test/core/parse/GdScriptParserTest.gd
+++ b/addons/gdUnit4/test/core/parse/GdScriptParserTest.gd
@@ -121,6 +121,29 @@ func test_parse_arguments_default_build_in_type_string() -> void:
 		])
 
 
+func test_parse_arguments_default_build_in_type_string_with_escaped_quote() -> void:
+	# https://github.com/godot-gdunit-labs/gdUnit4/issues/1309
+	# an escaped double quote inside a callable argument value must not be treated as the string end
+	assert_array(_parser._parse_function_arguments(
+		"""func foo(arg1: String, arg2: String, test_parameters := _parameters_string_arg('abc', "d\\"ef")):"""))\
+		.has_size(3)\
+		.contains([
+			{"name" : "arg1", "type" : TYPE_STRING, "value" : GdFunctionArgument.UNDEFINED},
+			{"name" : "arg2", "type" : TYPE_STRING, "value" : GdFunctionArgument.UNDEFINED},
+			{"name" : "test_parameters", "type" : TYPE_VARIANT, "value" : """_parameters_string_arg('abc', "d\\"ef")"""},
+		])
+
+	# same for an escaped single quote inside a single quoted argument value
+	assert_array(_parser._parse_function_arguments(
+		"""func foo(arg1: String, arg2: String, test_parameters := _parameters_string_arg("abc", 'd\\'ef')):"""))\
+		.has_size(3)\
+		.contains([
+			{"name" : "arg1", "type" : TYPE_STRING, "value" : GdFunctionArgument.UNDEFINED},
+			{"name" : "arg2", "type" : TYPE_STRING, "value" : GdFunctionArgument.UNDEFINED},
+			{"name" : "test_parameters", "type" : TYPE_VARIANT, "value" : """_parameters_string_arg("abc", 'd\\'ef')"""},
+		])
+
+
 func test_parse_arguments_default_build_in_type_boolean() -> void:
 	assert_array(_parser._parse_function_arguments("func foo(arg1 :String, arg2=false):")) \
 		.has_size(2)\


### PR DESCRIPTION
## Why

Escaped quotes inside a parameterized test's argument values crashed GdUnit4's test discovery, so a parameterized test could not use string values containing an escaped double or single quote.

## What

- Fixed the argument parsing used during test discovery to correctly skip escaped quotes when locating the end of a string value, instead of misreading them as the string's boundary.
- Fixed a related bug where a quote of the other quote type inside a value could corrupt bracket tracking and merge two separate parameter sets into one.
- Added regression tests covering escaped double and single quotes for both parameterized-test styles.

Closes #1309