### PR TITLE
GD-1323: Use `usr/bin/env bash` shebang in `run_tests.sh`

### DIFF
--- a/addons/gdUnit4/runtest.sh
+++ b/addons/gdUnit4/runtest.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Check for command-line argument
 godot_binary=""


### PR DESCRIPTION
# Why
In some Linux distros, `bash` isn't located in `/bin/bash`. For example: NixOS does not have a `/bin/bash`, but it does have `/usr/bin/env`.

By using `/usr/bin/env`, we can make the script more distro-agnostic.


# What
Change the shebang from `/bin/bash` to `/usr/bin/env bash`.

Closes https://github.com/godot-gdunit-labs/gdUnit4/issues/1323
