### PR TITLE
DOC-1325: Pointing issue templates to the new repository and docs URLs

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -12,7 +12,7 @@ body:
     attributes:
       value: |
         ### Thanks for taking the time to fill out this bug report!
-        - Please search [open](https://github.com/MikeSchulze/gdUnit4/issues?q=is%3Aissue) for existing issues for
+        - Please search [open](https://github.com/godot-gdunit-labs/gdUnit4/issues?q=label%3Abug%20is%3Aissue) for existing issues for
           potential duplicates before filing yours.
         - Verify that you are using a [supported Godot version](https://docs.godotengine.org/en/stable/about/release_policy.html).
           Please always check if your issue is reproducible in the latest version – it may already have been fixed!

--- a/.github/ISSUE_TEMPLATE/documentation.yml
+++ b/.github/ISSUE_TEMPLATE/documentation.yml
@@ -12,8 +12,8 @@ body:
     attributes:
       value: |
         ### Thanks for helping improve GdUnit4 documentation!
-        - Please search [existing documentation issues](https://github.com/MikeSchulze/gdUnit4/issues?q=label%3Adocumentation%20is%3Aissue) to avoid duplicates
-        - Check the [official GdUnit4 documentation](https://mikeschulze.github.io/gdUnit4/) first
+        - Please search [existing documentation issues](https://github.com/godot-gdunit-labs/gdUnit4/issues?q=label%3Adocumentation%20is%3Aissue) to avoid duplicates
+        - Check the [official GdUnit4 documentation](https://godot-gdunit-labs.github.io/gdUnit4/latest/) first
         - Consider if this might be better as a GitHub Discussion for questions
 
   - type: dropdown
@@ -65,7 +65,7 @@ body:
     attributes:
       label: Documentation Link (if applicable)
       description: Link to the specific documentation page
-      placeholder: https://mikeschulze.github.io/gdUnit4/path/to/page
+      placeholder: https://godot-gdunit-labs.github.io/gdUnit4/path/to/page
     validations:
       required: true
 

--- a/.github/ISSUE_TEMPLATE/documentation.yml
+++ b/.github/ISSUE_TEMPLATE/documentation.yml
@@ -12,7 +12,7 @@ body:
     attributes:
       value: |
         ### Thanks for helping improve GdUnit4 documentation!
-        - Please search [existing documentation issues](https://github.com/godot-gdunit-labs/gdUnit4/issues?q=label%3Adocumentation%20is%3Aissue) to avoid duplicates
+        - Please search [existing issues](https://github.com/godot-gdunit-labs/gdUnit4/issues?q=label%3Adocumentation%20is%3Aissue) to avoid duplicates
         - Check the [official GdUnit4 documentation](https://godot-gdunit-labs.github.io/gdUnit4/latest/) first
         - Consider if this might be better as a GitHub Discussion for questions
 

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -12,7 +12,7 @@ body:
     attributes:
       value: |
         ### Thanks for suggesting a new feature!
-        - Please search [existing feature requests](https://github.com/MikeSchulze/gdUnit4/issues?q=label%3Aenhancement%20is%3Aissue) to avoid duplicates
+        - Please search [existing feature requests](https://github.com/godot-gdunit-labs/gdUnit4/issues?q=label%3Aenhancement%20is%3Aissue) to avoid duplicates
         - Consider if this might be better as a GitHub Discussion to gather community feedback first
         - Check if this feature might already exist in the latest version
 

--- a/.github/ISSUE_TEMPLATE/improvement.yml
+++ b/.github/ISSUE_TEMPLATE/improvement.yml
@@ -12,7 +12,7 @@ body:
     attributes:
       value: |
         ### Thanks for suggesting code improvements!
-        - Please search [existing improvement issues](https://github.com/MikeSchulze/gdUnit4/issues?q=label%3Aimprovement%20is%3Aissue) to avoid duplicates
+        - Please search [existing improvement issues](https://github.com/godot-gdunit-labs/gdUnit4/issues?q=label%3Aimprovement%20is%3Aissue) to avoid duplicates
         - Consider the impact on existing users and backward compatibility
         - Focus on improving code quality, maintainability, or performance
 

--- a/.github/ISSUE_TEMPLATE/improvement.yml
+++ b/.github/ISSUE_TEMPLATE/improvement.yml
@@ -12,7 +12,7 @@ body:
     attributes:
       value: |
         ### Thanks for suggesting code improvements!
-        - Please search [existing improvement issues](https://github.com/godot-gdunit-labs/gdUnit4/issues?q=label%3Aimprovement%20is%3Aissue) to avoid duplicates
+        - Please search [existing issues](https://github.com/godot-gdunit-labs/gdUnit4/issues?q=label%3Aimprovement%20is%3Aissue) to avoid duplicates
         - Consider the impact on existing users and backward compatibility
         - Focus on improving code quality, maintainability, or performance
 

--- a/.github/ISSUE_TEMPLATE/task.yml
+++ b/.github/ISSUE_TEMPLATE/task.yml
@@ -14,7 +14,7 @@ body:
         ### A Task is not a bug or feature request!
         Tasks are for small implementation work, maintenance, or improvements that don't change the public API.
 
-        - Please search [existing tasks](https://github.com/MikeSchulze/gdUnit4/issues?q=label%3Atask%20is%3Aissue) to avoid duplicates
+        - Please search [existing tasks](https://github.com/godot-gdunit-labs/gdUnit4/issues?q=label%3Atask%20is%3Aissue) to avoid duplicates
         - Consider if this should be a bug report, feature request, or refactoring issue instead
         - Keep tasks focused and small for easier completion
 


### PR DESCRIPTION
## Why

Issue templates linked to the old GitHub organization and a dead documentation domain.

## What

Repointed all issue template links to the godot-gdunit-labs organization and its current documentation URL.

Closes #1325